### PR TITLE
Fix haddock documentation cross module links

### DIFF
--- a/password/src/Data/Password.hs
+++ b/password/src/Data/Password.hs
@@ -24,15 +24,15 @@ function of the respective algorithm.
 
 == Algorithms
 
-Generally, the most "secure" algorithm is believed to be @"Data.Password.Argon2"@,
-then @"Data.Password.Scrypt"@, then @"Data.Password.Bcrypt"@, and lastly
-@"Data.Password.PBKDF2"@. @"Data.Password.Bcrypt"@ and @"Data.Password.PBKDF2"@
-are the most established algorithms, so they have been tried and tested, though
-they both lack a memory cost, and therefore have a greater vulnerability to
-specialized hardware attacks.
+Generally, the most "secure" algorithm is believed to be @'Data.Password.Argon2.Argon2'@,
+then @'Data.Password.Scrypt.Scrypt'@, then @'Data.Password.Bcrypt.Bcrypt'@, and lastly
+@'Data.Password.PBKDF2.PBKDF2'@. @'Data.Password.Bcrypt.Bcrypt'@
+and @'Data.Password.PBKDF2.PBKDF2'@ are the most established algorithms, so they have
+been tried and tested, though they both lack a memory cost, and therefore have a
+greater vulnerability to specialized hardware attacks.
 
 When choosing an algorithm, and you have no idea which to pick, just go for
-@"Data.Password.Bcrypt"@ if your password does not need the highest security possible.
+@'Data.Password.Bcrypt.Bcrypt'@ if your password does not need the highest security possible.
 It's still a fine way for hashing passwords, and the cost is easily adjustable if needed.
 If your needs do require stronger protection, you should find someone who can advise you
 on this topic. (And if you're already knowledgeable enough, you know what to do)

--- a/password/src/Data/Password.hs
+++ b/password/src/Data/Password.hs
@@ -24,14 +24,15 @@ function of the respective algorithm.
 
 == Algorithms
 
-Generally, the most "secure" algorithm is believed to be @"Argon2"@,
-then @"Scrypt"@, then @"Bcrypt"@, and lastly @"PBKDF2"@. @"Bcrypt"@ and @"PBKDF2"@
+Generally, the most "secure" algorithm is believed to be @"Data.Password.Argon2"@,
+then @"Data.Password.Scrypt"@, then @"Data.Password.Bcrypt"@, and lastly
+@"Data.Password.PBKDF2"@. @"Data.Password.Bcrypt"@ and @"Data.Password.PBKDF2"@
 are the most established algorithms, so they have been tried and tested, though
 they both lack a memory cost, and therefore have a greater vulnerability to
 specialized hardware attacks.
 
 When choosing an algorithm, and you have no idea which to pick, just go for
-@"Bcrypt"@ if your password does not need the highest security possible.
+@"Data.Password.Bcrypt"@ if your password does not need the highest security possible.
 It's still a fine way for hashing passwords, and the cost is easily adjustable if needed.
 If your needs do require stronger protection, you should find someone who can advise you
 on this topic. (And if you're already knowledgeable enough, you know what to do)

--- a/password/src/Data/Password/Argon2.hs
+++ b/password/src/Data/Password/Argon2.hs
@@ -30,7 +30,7 @@ All three modes allow specification by three parameters that control:
 In comparison to other algorithms, Argon2 is the least "battle-tested",
 being the newest algorithm out there.
 
-It is, however, recommended over @"Scrypt"@ most of the time,
+It is, however, recommended over @"Data.Password.Scrypt"@ most of the time,
 and it also seems like it might become the go-to password algorithm if no
 vulnarabilities are discovered within the next couple of years.
 -}

--- a/password/src/Data/Password/Argon2.hs
+++ b/password/src/Data/Password/Argon2.hs
@@ -30,7 +30,7 @@ All three modes allow specification by three parameters that control:
 In comparison to other algorithms, Argon2 is the least "battle-tested",
 being the newest algorithm out there.
 
-It is, however, recommended over @"Data.Password.Scrypt"@ most of the time,
+It is, however, recommended over @'Data.Password.Scrypt.Scrypt'@ most of the time,
 and it also seems like it might become the go-to password algorithm if no
 vulnarabilities are discovered within the next couple of years.
 -}

--- a/password/src/Data/Password/Bcrypt.hs
+++ b/password/src/Data/Password/Bcrypt.hs
@@ -19,10 +19,10 @@ and generally considered to provide a good amount of security.
 
 == Other algorithms
 
-@bcrypt@, together with @"PBKDF2"@, are only computationally intensive.
+@bcrypt@, together with @"Data.Password.PBKDF2"@, are only computationally intensive.
 And to protect from specialized hardware, new algorithms have been
-developed that are also resource intensive, like @"Scrypt"@ and
-@"Argon2"@. Not having high resource demands, means an attacker with
+developed that are also resource intensive, like @"Data.Password.Scrypt"@ and
+@"Data.Password.Argon2"@. Not having high resource demands, means an attacker with
 specialized software could take less time to brute-force a password,
 though with the default cost (10) and a decently long password,
 the amount of time to brute-force would still be significant.

--- a/password/src/Data/Password/Bcrypt.hs
+++ b/password/src/Data/Password/Bcrypt.hs
@@ -19,10 +19,10 @@ and generally considered to provide a good amount of security.
 
 == Other algorithms
 
-@bcrypt@, together with @"Data.Password.PBKDF2"@, are only computationally intensive.
+@bcrypt@, together with @'Data.Password.PBKDF2.PBKDF2'@, are only computationally intensive.
 And to protect from specialized hardware, new algorithms have been
-developed that are also resource intensive, like @"Data.Password.Scrypt"@ and
-@"Data.Password.Argon2"@. Not having high resource demands, means an attacker with
+developed that are also resource intensive, like @'Data.Password.Scrypt.Scrypt'@ and
+@'Data.Password.Argon2.Argon2'@. Not having high resource demands, means an attacker with
 specialized software could take less time to brute-force a password,
 though with the default cost (10) and a decently long password,
 the amount of time to brute-force would still be significant.

--- a/password/src/Data/Password/PBKDF2.hs
+++ b/password/src/Data/Password/PBKDF2.hs
@@ -28,7 +28,8 @@ passwords.
 
 Seeing as PBKDF2 is shown to be very weak in terms of protection
 against GPU cracking attacks, it is generally advised to go with
-@"Bcrypt"@, if not @"Scrypt"@ or @"Argon2"@. When unsure, @"Bcrypt"@
+@"Data.Password.Bcrypt"@, if not @"Data.Password.Scrypt"@ or @"Data.Password.Argon2"@.
+When unsure, @"Data.Password.Bcrypt"@
 would probably be the safest option, as it has no memory cost which
 could become a problem if not properly calibrated to the machine
 doing the password verifications.

--- a/password/src/Data/Password/PBKDF2.hs
+++ b/password/src/Data/Password/PBKDF2.hs
@@ -28,8 +28,9 @@ passwords.
 
 Seeing as PBKDF2 is shown to be very weak in terms of protection
 against GPU cracking attacks, it is generally advised to go with
-@"Data.Password.Bcrypt"@, if not @"Data.Password.Scrypt"@ or @"Data.Password.Argon2"@.
-When unsure, @"Data.Password.Bcrypt"@
+@'Data.Password.Bcrypt.Bcrypt'@, if not @'Data.Password.Scrypt.Scrypt'@
+or @'Data.Password.Argon2.Argon2'@.
+When unsure, @'Data.Password.Bcrypt.Bcrypt'@
 would probably be the safest option, as it has no memory cost which
 could become a problem if not properly calibrated to the machine
 doing the password verifications.

--- a/password/src/Data/Password/Scrypt.hs
+++ b/password/src/Data/Password/Scrypt.hs
@@ -18,16 +18,16 @@ designed to be costly by requiring large amounts of memory.
 == Other algorithms
 
 @scrypt@ does increase the memory requirement in contrast to
-@"Data.Password.Bcrypt"@ and @"Data.Password.PBKDF2"@, but it
+@'Data.Password.Bcrypt.Bcrypt'@ and @'Data.Password.PBKDF2.PBKDF2'@, but it
 turns out it is not as optimal as it could be, and thus others have set out
 to search for other algorithms that do fulfill on their promises.
-@"Data.Password.Argon2"@ seems to be the winner in that search.
+@'Data.Password.Argon2.Argon2'@ seems to be the winner in that search.
 
 That is not to say using @scrypt@ somehow means your passwords
 won't be properly protected. The cryptography is sound and
 thus is fine for protection against brute-force attacks.
 Because of the memory cost, it is generally advised to use
-@"Data.Password.Bcrypt"@ if you're not sure this might be a
+@'Data.Password.Bcrypt.Bcrypt'@ if you're not sure this might be a
 problem on your system.
 -}
 

--- a/password/src/Data/Password/Scrypt.hs
+++ b/password/src/Data/Password/Scrypt.hs
@@ -18,16 +18,16 @@ designed to be costly by requiring large amounts of memory.
 == Other algorithms
 
 @scrypt@ does increase the memory requirement in contrast to
-@"Bcrypt"@ and @"PBKDF2"@, but it turns out it is not as optimal
-as it could be, and thus others have set out to search for other
-algorithms that do fulfill on their promises. @"Argon2"@ seems
-to be the winner in that search.
+@"Data.Password.Bcrypt"@ and @"Data.Password.PBKDF2"@, but it
+turns out it is not as optimal as it could be, and thus others have set out
+to search for other algorithms that do fulfill on their promises.
+@"Data.Password.Argon2"@ seems to be the winner in that search.
 
 That is not to say using @scrypt@ somehow means your passwords
 won't be properly protected. The cryptography is sound and
 thus is fine for protection against brute-force attacks.
 Because of the memory cost, it is generally advised to use
-@"Bcrypt"@ if you're not sure this might be a
+@"Data.Password.Bcrypt"@ if you're not sure this might be a
 problem on your system.
 -}
 


### PR DESCRIPTION
## Fix haddock documentation cross module links

Thsi change fixes the cross module references links.

Fixes #17

## Use direct module link to remove the Data.Password prefix
