### PR TITLE
upped cryptonite deps constraint to '< 0.28'

### DIFF
--- a/password/password.cabal
+++ b/password/password.cabal
@@ -43,7 +43,7 @@ library
       base        >= 4.9      && < 5
     , base64      >= 0.3      && < 0.5
     , bytestring  >= 0.10.8.1 && < 0.11
-    , cryptonite  >= 0.15.1   && < 0.27
+    , cryptonite  >= 0.15.1   && < 0.28
     , memory      >= 0.14     && < 0.16
     , text        >= 1.2.2    && < 1.3
   ghc-options:


### PR DESCRIPTION
This change doesn't need a version increase. The package on hackage has been revised to accomodate this change.