### PR TITLE
Some additions / modifications to password validation

### DIFF
--- a/hie.yaml
+++ b/hie.yaml
@@ -1,0 +1,14 @@
+cradle:
+    stack:
+        - path: "./password/src"
+          component: "password:lib"
+        - path: "./password/test/doctest"
+          component: "password:test:doctests"
+        - path: "./password/test/tasty"
+          component: "password:test:password-tasty"
+        - path: "./password-instances/src"
+          component: "password-instances:lib"
+        - path: "./password-instances/test/doctest"
+          component: "password-instances:test:doctests"
+        - path: "./password-instances/test/tasty"
+          component: "password-instances:test:password-instances-tasty"

--- a/password/ChangeLog.md
+++ b/password/ChangeLog.md
@@ -6,12 +6,15 @@
     should adhere to and the necessary API to verify that they do.
     [#26](https://github.com/cdepillabout/password/pull/26)
     Huge thanks to [@HirotoShioi](https://github.com/HirotoShioi) for picking
-    up the task of adding this functionality and doing most of the work.
+    up the task of adding this functionality and doing most of the groundwork.
+    [#27](https://github.com/cdepillabout/password/pull/27)
+    Thanks to Felix Paulusma ([@Vlix](https://github.com/Vlix)) for finishing
+    up the API and documentation.
 
 ## 2.0.1.1
 
--   Fixed cross-module links in the haddocks
-    [#19](https://github.com/cdepillabout/password/pull/19). Thanks to
+-   Fixed cross-module links in the haddocks.
+    [#19](https://github.com/cdepillabout/password/pull/19) Thanks to
     [@TristanCacqueray](https://github.com/TristanCacqueray) for fixing this.
 
 ## 2.0.1.0
@@ -19,8 +22,7 @@
 -   Switched checking hashes to using `Data.ByteArray.constEq`, instead of
     the default `(==)` method of `ByteString`. This is to make it more secure
     against timing attacks. [#16](https://github.com/cdepillabout/password/pull/16)
-    Thanks to maralorn ([@maralorn](https://github.com/maralorn)) for bringing
-    this up.
+    Thanks to [@maralorn](https://github.com/maralorn) for bringing this up.
 
 ## 2.0.0.1
 

--- a/password/ChangeLog.md
+++ b/password/ChangeLog.md
@@ -1,9 +1,17 @@
 # Changelog for password
 
+## 2.1.0.0
+
+-   A new `Validate` module has been added to dictate policies that passwords
+    should adhere to and the necessary API to verify that they do.
+    [#26](https://github.com/cdepillabout/password/pull/26)
+    Huge thanks to [@HirotoShioi](https://github.com/HirotoShioi) for picking
+    up the task of adding this functionality and doing most of the work.
+
 ## 2.0.1.1
 
 -   Fixed cross-module links in the haddocks
-    [#19](https://github.com/cdepillabout/password/pull/19).  Thanks to
+    [#19](https://github.com/cdepillabout/password/pull/19). Thanks to
     [@TristanCacqueray](https://github.com/TristanCacqueray) for fixing this.
 
 ## 2.0.1.0

--- a/password/password.cabal
+++ b/password/password.cabal
@@ -98,6 +98,7 @@ test-suite password-tasty
     , quickcheck-instances
     , scrypt
     , tasty
+    , tasty-hunit
     , tasty-quickcheck
     , text
   default-language:

--- a/password/password.cabal
+++ b/password/password.cabal
@@ -85,6 +85,7 @@ test-suite password-tasty
     , Internal
     , PBKDF2
     , Scrypt
+    , TestPolicy
     , Validate
     , Paths_password
   ghc-options:

--- a/password/password.cabal
+++ b/password/password.cabal
@@ -1,7 +1,7 @@
 cabal-version: 1.12
 
 name:           password
-version:        2.0.1.1
+version:        2.1.0.0
 category:       Data
 synopsis:       Hashing and checking of passwords
 description:    A library providing functionality for working with plain-text and hashed passwords with different types of algorithms.

--- a/password/password.cabal
+++ b/password/password.cabal
@@ -46,6 +46,7 @@ library
     , bytestring  >= 0.10.8.1 && < 0.11
     , cryptonite  >= 0.15.1   && < 0.27
     , memory      >= 0.14     && < 0.16
+    , template-haskell
     , text        >= 1.2.2    && < 1.3
   ghc-options:
       -Wall

--- a/password/src/Data/Password/Internal.hs
+++ b/password/src/Data/Password/Internal.hs
@@ -141,4 +141,3 @@ readT = readMaybe . T.unpack
 showT :: forall a. Show a => a -> Text
 showT = T.pack . show
 {-# INLINE showT #-}
-

--- a/password/src/Data/Password/Validate.hs
+++ b/password/src/Data/Password/Validate.hs
@@ -112,8 +112,9 @@ newtype CharSetPredicate = CharSetPredicate
   }
 
 
--- | Default character sets consist of uppercase and lowercase letters, numbers,
+-- | The default character set consists of uppercase and lowercase letters, numbers,
 -- and special characters from the ASCII character set.
+-- (i.e. everything from the ASCII set except the control characters)
 --
 -- @since 2.1.0.0
 defaultCharSetPredicate :: CharSetPredicate
@@ -121,6 +122,7 @@ defaultCharSetPredicate =  CharSetPredicate $ \c -> ord c >= 32 && ord c <= 126
 {-# INLINE defaultCharSetPredicate #-}
 
 -- | Check if given 'Char' is a special character.
+-- (i.e. any non-alphanumeric non-control ASCII character)
 --
 -- @since 2.1.0.0
 isSpecial :: Char -> Bool
@@ -205,7 +207,7 @@ data ValidationResult
 -- | Checks if the given 'Password' adheres to the given 'PasswordPolicy'
 -- and 'CharSetPredicate', and returns @True@ if given a valid password.
 --
--- This function is equivalent to @validatePassword policy charSetPredicate password == ValidPassword@
+-- This function is equivalent to @'validatePassword' policy charSetPredicate password == 'ValidPassword'@
 --
 -- >>> let pass = mkPassword "This_Is_Valid_PassWord1234"
 -- >>> isValidPassword defaultPasswordPolicy defaultCharSetPredicate pass

--- a/password/src/Data/Password/Validate.hs
+++ b/password/src/Data/Password/Validate.hs
@@ -213,7 +213,7 @@ data ValidationResult
 --
 -- @since 2.1.0.0
 isValidPassword :: PasswordPolicy -> CharSetPredicate -> Password -> Bool
-isValidPassword policy pre pass = (==) ValidPassword $ validatePassword policy pre pass
+isValidPassword policy pre pass = validatePassword policy pre pass == ValidPassword
 {-# INLINE isValidPassword #-}
 
 -- | Check if given 'Password' fulfills all of the Policies, returns list of

--- a/password/src/Data/Password/Validate.hs
+++ b/password/src/Data/Password/Validate.hs
@@ -275,7 +275,7 @@ data ValidationResult = ValidPassword | InvalidPassword [InvalidReason]
 -- This function is equivalent to @'validatePassword' policy charSetPredicate password == 'ValidPassword'@
 --
 -- >>> let pass = mkPassword "This_Is_Valid_PassWord1234"
--- >>> isValidPassword defaultPasswordPolicy defaultCharSetPredicate pass
+-- >>> isValidPassword defaultPasswordPolicy_ pass
 -- True
 --
 -- @since 2.1.0.0
@@ -288,7 +288,7 @@ isValidPassword policy pass = validatePassword policy pass == ValidPassword
 -- Note that if the 'PasswordPolicy' is invalid, this will never return 'ValidPassword'.
 --
 -- >>> let pass = mkPassword "This_Is_Valid_Password1234"
--- >>> validatePassword defaultPasswordPolicy pass
+-- >>> validatePassword defaultPasswordPolicy_ pass
 -- ValidPassword
 --
 -- @since 2.1.0.0

--- a/password/src/Data/Password/Validate.hs
+++ b/password/src/Data/Password/Validate.hs
@@ -302,7 +302,7 @@ defaultCharSetPredicate =  CharSetPredicate $ \c -> ord c >= 32 && ord c <= 126
 -- @since 2.1.0.0
 isSpecial :: Char -> Bool
 isSpecial = \c ->
-    isDefault c && not (or [isAsciiUpper c, isAsciiLower c, isDigit c])
+    isDefault c && not (isAsciiUpper c || isAsciiLower c || isDigit c)
   where
     CharSetPredicate isDefault = defaultCharSetPredicate
 

--- a/password/src/Data/Password/Validate.hs
+++ b/password/src/Data/Password/Validate.hs
@@ -30,7 +30,7 @@ module Data.Password.Validate
     validatePasswordPolicy,
     PasswordPolicy (..),
     ValidPasswordPolicy,
-    unValidatePasswordPolicy,
+    fromValidPasswordPolicy,
     defaultPasswordPolicy,
     defaultPasswordPolicy_,
     CharSetPredicate(..),
@@ -145,8 +145,13 @@ instance Show PasswordPolicy where
 --
 -- @since 2.1.0.0
 newtype ValidPasswordPolicy = VPP
-  { unValidatePasswordPolicy :: PasswordPolicy
-  } deriving (Eq, Show)
+  { fromValidPasswordPolicy :: PasswordPolicy
+    -- ^
+    -- In case you'd want to retrieve the 'PasswordPolicy'
+    -- from the 'ValidPasswordPolicy'
+    --
+    -- @since 2.1.0.0
+  } deriving (Eq, Ord, Show)
 
 -- | Default value for the 'PasswordPolicy'.
 --

--- a/password/test/tasty/TestPolicy.hs
+++ b/password/test/tasty/TestPolicy.hs
@@ -1,0 +1,21 @@
+module TestPolicy where
+
+import Data.Password.Validate (
+    PasswordPolicy (..),
+    defaultPasswordPolicy,
+ )
+
+-- This is used for the TH test just so it would be obvious if
+-- any numbers suddenly switched between fields.
+-- (e.g. uppercaseChars and lowercaseChars suddenly switch places
+-- after going through validatePasswordPolicyTH)
+testPolicy :: PasswordPolicy
+testPolicy =
+    defaultPasswordPolicy
+        { minimumLength = 8
+        , maximumLength = 64
+        , uppercaseChars = 3
+        , lowercaseChars = 4
+        , specialChars = 5
+        , digitChars = 6
+        }

--- a/password/test/tasty/Validate.hs
+++ b/password/test/tasty/Validate.hs
@@ -22,7 +22,7 @@ import Data.Semigroup ((<>))
 
 import Data.Password (Password, mkPassword)
 import Data.Password.Validate hiding (ValidationResult(..))
-import qualified Data.Password.Validate as Validate
+import qualified Data.Password.Validate as V
 
 -- | Set of tests used for testing validate module
 testValidate :: TestTree
@@ -134,7 +134,7 @@ validDefaultCharSetPredicate =
 
 validDefaultPassword :: Assertion
 validDefaultPassword =
-  assertEqual "defaultPassword isn't valid" Validate.ValidPassword
+  assertEqual "defaultPassword isn't valid" V.ValidPassword
     $ validatePassword
         defaultPasswordPolicy
         defaultCharSetPredicate
@@ -177,7 +177,7 @@ prop_ValidPassword :: ValidPassword -> Property
 prop_ValidPassword (ValidPassword passwordPolicy predicate password) =
   withMaxSuccess 1000 $ do
     validatePassword passwordPolicy predicate (mkPassword password)
-      === Validate.ValidPassword
+      === V.ValidPassword
 
 -- | Data type used to generate valid password and 'PasswordPolicy' associated
 -- with it
@@ -213,9 +213,7 @@ prop_InvalidPassword (InvalidPassword failedReason passwordPolicy charSetPredica
     validatePassword passwordPolicy charSetPredicate (mkPassword password)
       === expected failedReason
   where
-    expected = either
-      (Validate.InvalidPolicy . pure)
-      (Validate.InvalidPassword . pure)
+    expected = either (V.InvalidPolicy . pure) (V.InvalidPassword . pure)
 
 -- | Data type used to generate password which does not follow one of the policies
 -- as well as 'InvalidReason', 'CharSetPredicate', and 'PasswordPolicy' associated with it

--- a/password/test/tasty/Validate.hs
+++ b/password/test/tasty/Validate.hs
@@ -114,7 +114,7 @@ props_validatePasswordPolicy =
       \i -> let maxLen = maximumLength defaultPasswordPolicy
                 mLength = [InvalidLength i maxLen | i > maxLen]
                 policy = defaultPasswordPolicy { minimumLength = i }
-                result = unValidatePasswordPolicy <$> validatePasswordPolicy policy
+                result = fromValidPasswordPolicy <$> validatePasswordPolicy policy
                 expected = case mLength of
                   [] -> Right policy
                   _ -> Left mLength
@@ -125,7 +125,7 @@ props_validatePasswordPolicy =
                 mZero = [MaxLengthBelowZero i | i <= 0]
                 reasons = mZero ++ mLength
                 policy = defaultPasswordPolicy { maximumLength = i }
-                result = unValidatePasswordPolicy <$> validatePasswordPolicy policy
+                result = fromValidPasswordPolicy <$> validatePasswordPolicy policy
                 expected = case reasons of
                   [] -> Right policy
                   _ -> Left reasons
@@ -134,7 +134,7 @@ props_validatePasswordPolicy =
   where
     validProp f i =
       let p = f i
-          result = unValidatePasswordPolicy <$> validatePasswordPolicy p
+          result = fromValidPasswordPolicy <$> validatePasswordPolicy p
       in result === Right p
 
 validDefaultPasswordPolicy :: Assertion
@@ -142,7 +142,7 @@ validDefaultPasswordPolicy = do
   assertBool "defaultPasswordPolicy isn't a valid policy"
     $ isRight $ validatePasswordPolicy defaultPasswordPolicy
   assertBool "defaultPasswordPolicy_ isn't a valid policy"
-    $ isRight $ validatePasswordPolicy $ unValidatePasswordPolicy defaultPasswordPolicy_
+    $ isRight $ validatePasswordPolicy $ fromValidPasswordPolicy defaultPasswordPolicy_
 
 validDefaultCharSetPredicate :: Assertion
 validDefaultCharSetPredicate =

--- a/password/test/tasty/Validate.hs
+++ b/password/test/tasty/Validate.hs
@@ -9,6 +9,7 @@ module Validate where
 
 import Control.Monad (replicateM)
 import Data.Char (chr, isAsciiLower, isAsciiUpper, isControl, isDigit)
+import Data.List (nub)
 import Data.Text (Text)
 import qualified Data.Text as T
 import Test.QuickCheck.Instances.Text ()
@@ -162,8 +163,12 @@ validDefaultPasswordPolicy = do
 
 templateHaskellTest :: [TestTree]
 templateHaskellTest =
-    [ testCase "Internal consistency" $ assertEqual
-        "validatePasswordPolicyTH changed the values of defaultPasswordPolicy"
+    [ testCase "allButCSP check" $ assertBool
+        "testPolicy doesn't have unique values"
+        $ let ns = V.allButCSP testPolicy
+          in nub ns == ns
+    , testCase "Internal consistency" $ assertEqual
+        "validatePasswordPolicyTH switched values between fields"
         testPolicy
         $ fromValidPasswordPolicy $(validatePasswordPolicyTH testPolicy)
     , testCase "defaultPassword" $ assertBool


### PR DESCRIPTION
I went through the `validate-password` code on my own laptop at some point and checked the comments, tried to make it a bit more DRY and tried to separate the policy validation from the password validation.

I'll probably do a last pass over the entire module for correctness and reader-friendliness just before we'll merge everything in.