### PR TITLE
password/test: 'pred' was shadowing a Prelude function

### DIFF
--- a/password/test/tasty/Validate.hs
+++ b/password/test/tasty/Validate.hs
@@ -181,9 +181,9 @@ templateHaskellTest =
             defaultPassword
     , testProperty "prop test for charSetPredicate after TH" $ \(PredInts i) ->
         let policy = $(validatePasswordPolicyTH defaultPasswordPolicy{ charSetPredicate = CharSetPredicate $ const False})
-            pred = getCharSetPredicate . charSetPredicate $ fromValidPasswordPolicy policy
+            p = getCharSetPredicate . charSetPredicate $ fromValidPasswordPolicy policy
             c = chr i
-        in pred c == (c `elem` defaultCharSet)
+        in p c == (c `elem` defaultCharSet)
     ]
 
 newtype PredInts = PredInts { unPredInts :: Int } deriving (Eq, Show)


### PR DESCRIPTION
It was, and I somehow didn't notice. Not that big of a deal, though.