### PR TITLE
bump dependency versions of cryptonite and memory

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   cabal:
-    name: ${{ matrix.os }} / ghc ${{ matrix.ghc }}
+    name: cabal / ghc-${{matrix.ghc}} / ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
@@ -21,13 +21,13 @@ jobs:
           - "8.4.4"
           - "8.6.5"
           - "8.8.4"
-          - "8.10.2"
+          - "8.10.4"
 
     steps:
     - uses: actions/checkout@v2
       #if: github.event.action == 'opened' || github.event.action == 'synchronize' || github.event.ref == 'refs/heads/master'
 
-    - uses: actions/setup-haskell@v1.1.4
+    - uses: haskell/actions/setup@v1
       id: setup-haskell-cabal
       name: Setup Haskell
       with:
@@ -67,16 +67,18 @@ jobs:
           - "--resolver lts-12 --stack-yaml ./stack-lts-14.yaml" # GHC 8.4.4
           - "--resolver lts-14 --stack-yaml ./stack-lts-14.yaml" # GHC 8.6.5
           - "--resolver lts-16" # GHC 8.8.4
+          - "--resolver lts-17" # GHC 8.10.4
           - "--resolver nightly" # GHC 8.10.* ?
 
     steps:
     - uses: actions/checkout@v2
       #if: github.event.action == 'opened' || github.event.action == 'synchronize' || github.event.ref == 'refs/heads/master'
 
-    - uses: actions/setup-haskell@v1.1.4
+    - uses: haskell/actions/setup@v1
       name: Setup Haskell Stack
       with:
         stack-version: ${{ matrix.stack }}
+        enable-stack: true
 
     - uses: actions/cache@v1
       name: Cache ~/.stack

--- a/password-types/password-types.cabal
+++ b/password-types/password-types.cabal
@@ -37,7 +37,7 @@ library
   build-depends:
       base        >= 4.9 && < 5
     , bytestring            < 1
-    , memory                < 0.16
+    , memory                < 0.17
     , text                  < 1.3
   ghc-options:
       -Wall

--- a/password/password.cabal
+++ b/password/password.cabal
@@ -72,8 +72,8 @@ library
       base        >= 4.9      && < 5
     , base64      >= 0.3      && < 0.5
     , bytestring  >= 0.10.8.1 && < 0.11
-    , cryptonite  >= 0.15.1   && < 0.29
-    , memory      >= 0.14     && < 0.16
+    , cryptonite  >= 0.15.1   && < 0.30
+    , memory      >= 0.14     && < 0.17
     , password-types             < 2
     , template-haskell
     , text        >= 1.2.2    && < 1.3

--- a/stack.yaml
+++ b/stack.yaml
@@ -17,7 +17,7 @@
 #
 # resolver: ./custom-snapshot.yaml
 # resolver: https://example.com/snapshots/2018-01-01.yaml
-resolver: lts-16.27
+resolver: lts-17.10
 
 # User packages to be built.
 # Various formats can be used as shown in the example below.

--- a/stack.yaml.lock
+++ b/stack.yaml.lock
@@ -6,7 +6,7 @@
 packages: []
 snapshots:
 - completed:
-    size: 533252
-    url: https://raw.githubusercontent.com/commercialhaskell/stackage-snapshots/master/lts/16/27.yaml
-    sha256: c2aaae52beeacf6a5727c1010f50e89d03869abfab6d2c2658ade9da8ed50c73
-  original: lts-16.27
+    size: 567241
+    url: https://raw.githubusercontent.com/commercialhaskell/stackage-snapshots/master/lts/17/10.yaml
+    sha256: 321b3b9f0c7f76994b39e0dabafdc76478274b4ff74cc5e43d410897a335ad3b
+  original: lts-17.10


### PR DESCRIPTION
This bumps the versions of cryptonite and memory that we allow, since they both had new major releases:

- https://hackage.haskell.org/package/cryptonite-0.29
- https://hackage.haskell.org/package/memory-0.16.0

Unfortunately neither of them have CHANGELOGs for this new release...

In CI, you can see that these new versions of cryptonite and memory are being used, and our tests pass:

- cryptonite: https://github.com/cdepillabout/password/pull/49/checks?check_run_id=2537146239#step:5:70
- memory: https://github.com/cdepillabout/password/pull/49/checks?check_run_id=2537146239#step:5:50

This PR also bumps the LTS version in our `stack.yaml`, as well as some small fixups for our GitHub Action.  Closes #46.