### PR TITLE
Bump bounds for cryptonite and memory

### DIFF
--- a/password-types/password-types.cabal
+++ b/password-types/password-types.cabal
@@ -37,7 +37,7 @@ library
   build-depends:
       base        >= 4.9 && < 5
     , bytestring            < 1
-    , memory                < 0.17
+    , memory
     , text                  < 1.3
   ghc-options:
       -Wall

--- a/password/password.cabal
+++ b/password/password.cabal
@@ -72,7 +72,7 @@ library
       base        >= 4.9      && < 5
     , base64      >= 0.3      && < 0.5
     , bytestring  >= 0.10.8.1 && < 0.11
-    , cryptonite  >= 0.15.1   && < 0.30
+    , cryptonite  >= 0.15.1
     , memory      >= 0.14     && < 0.17
     , password-types             < 2
     , template-haskell

--- a/password/password.cabal
+++ b/password/password.cabal
@@ -73,7 +73,7 @@ library
     , base64      >= 0.3      && < 0.5
     , bytestring  >= 0.10.8.1 && < 0.11
     , cryptonite  >= 0.15.1
-    , memory      >= 0.14     && < 0.17
+    , memory      >= 0.14
     , password-types             < 2
     , template-haskell
     , text        >= 1.2.2    && < 1.3


### PR DESCRIPTION
The version bounds need to be bumped for cryptonite and memory:

- https://github.com/commercialhaskell/stackage/issues/6477
- https://github.com/commercialhaskell/stackage/issues/6480

I removed the upper version bounds instead of bumping them.  My justifications for this:

- `cryptonite` and `memory` are relatively stable packages.  There aren't too many huge breaking changes.  My guess is that it will be less work for us to add hackage revisions whenever we do happen to encounter breaking changes (rather than having to add a hackage revision every couple of months when new versions get released, along with an accompanying PR).
- We only use a small part of the entire `cryptonite` and `memory` APIs, so it is likely that we won't be affected even if there is a breaking change.

----------------------------------

In the meantime, I added revisions for `password` and `password-types` to bump the version bounds.  In these revisions, I did end up keeping the upper version bounds, just bumping them:

- https://hackage.haskell.org/package/password-types-1.0.0.0/revisions/
- https://hackage.haskell.org/package/password-3.0.1.0/revisions/