### PR TITLE
Control exposing hashing algorithms using Cabal flags

### DIFF
--- a/password/ChangeLog.md
+++ b/password/ChangeLog.md
@@ -1,5 +1,15 @@
 # Changelog for `password`
 
+## 3.0.2.1
+
+-   Add Cabal flags to control which hashing algorithms are exported. These flags are
+    `argon2`, `bcrypt`, `pbkdf2`, and `scrypt`. Each flag is enabled by default -
+    disabling it will elide the corresponding module from the library. This allows
+    downstream packagers to disable hashing algorithms which aren't supported on
+    certain platforms.
+    Thanks to [@ivanbakel](https://github.com/ivanbakel)
+    [#63](https://github.com/cdepillabout/password/pull/63)
+
 ## 3.0.2.0
 
 -   Add `extractParams` on `PasswordHash`s

--- a/password/password.cabal
+++ b/password/password.cabal
@@ -46,6 +46,26 @@ extra-source-files:
     README.md
     ChangeLog.md
 
+flag argon2
+  description: Compile with argon2 support?
+  default: True
+  manual: True
+
+flag bcrypt
+  description: Compile with Scrypt support?
+  default: True
+  manual: True
+
+flag pbkdf2
+  description: Compile with PBKDF2 support?
+  default: True
+  manual: True
+
+flag scrypt
+  description: Compile with Scrypt support?
+  default: True
+  manual: True
+
 custom-setup
   setup-depends:
       base
@@ -60,11 +80,19 @@ library
   hs-source-dirs:
       src
   exposed-modules:
-      Data.Password.Argon2
-      Data.Password.Bcrypt
-      Data.Password.PBKDF2
-      Data.Password.Scrypt
       Data.Password.Validate
+  if flag(argon2)
+    exposed-modules:
+        Data.Password.Argon2
+  if flag(bcrypt)
+    exposed-modules:
+        Data.Password.Bcrypt
+  if flag(pbkdf2)
+    exposed-modules:
+        Data.Password.PBKDF2
+  if flag(scrypt)
+    exposed-modules:
+        Data.Password.Scrypt
   other-modules:
       Paths_password
       Data.Password.Internal
@@ -110,14 +138,22 @@ test-suite password-tasty
   main-is:
       Spec.hs
   other-modules:
-      Argon2
-    , Bcrypt
-    , Internal
-    , PBKDF2
-    , Scrypt
+      Internal
     , TestPolicy
     , Validate
     , Paths_password
+  if flag(argon2)
+    other-modules:
+      Argon2
+  if flag(bcrypt)
+    other-modules:
+      Bcrypt
+  if flag(pbkdf2)
+    other-modules:
+      PBKDF2
+  if flag(scrypt)
+    other-modules:
+      Scrypt
   ghc-options:
       -threaded -O2 -rtsopts -with-rtsopts=-N
   build-depends:
@@ -135,3 +171,15 @@ test-suite password-tasty
     , text
   default-language:
       Haskell2010
+  if flag(argon2)
+    cpp-options:
+      -DCABAL_FLAG_argon2
+  if flag(bcrypt)
+    cpp-options:
+      -DCABAL_FLAG_bcrypt
+  if flag(pbkdf2)
+    cpp-options:
+      -DCABAL_FLAG_pbkdf2
+  if flag(scrypt)
+    cpp-options:
+      -DCABAL_FLAG_scrypt

--- a/password/password.cabal
+++ b/password/password.cabal
@@ -1,7 +1,7 @@
 cabal-version: 1.12
 
 name:           password
-version:        3.0.2.0
+version:        3.0.2.1
 category:       Data
 synopsis:       Hashing and checking of passwords
 description:

--- a/password/password.cabal
+++ b/password/password.cabal
@@ -134,11 +134,13 @@ test-suite password-tasty
   type:
       exitcode-stdio-1.0
   hs-source-dirs:
+      src
       test/tasty
   main-is:
       Spec.hs
   other-modules:
-      Internal
+      Data.Password.Internal
+    , Internal
     , TestPolicy
     , Validate
     , Paths_password
@@ -158,6 +160,7 @@ test-suite password-tasty
       -threaded -O2 -rtsopts -with-rtsopts=-N
   build-depends:
       base >=4.9 && <5
+    , base64
     , password
     , password-types
     , bytestring
@@ -168,6 +171,7 @@ test-suite password-tasty
     , tasty
     , tasty-hunit
     , tasty-quickcheck
+    , template-haskell
     , text
   default-language:
       Haskell2010

--- a/password/test/tasty/Internal.hs
+++ b/password/test/tasty/Internal.hs
@@ -7,8 +7,8 @@ import Test.Tasty (TestTree)
 import Test.Tasty.QuickCheck
 import Test.QuickCheck.Instances.Text ()
 
-import Data.Password.Types (mkPassword, Password, PasswordHash)
-import Data.Password.Bcrypt (PasswordCheck(..), Salt(..))
+import Data.Password.Types (mkPassword, Password, PasswordHash, Salt(..))
+import Data.Password.Internal (PasswordCheck(..))
 
 
 testCorrectPassword :: (Eq params, Show params)

--- a/password/test/tasty/Spec.hs
+++ b/password/test/tasty/Spec.hs
@@ -1,13 +1,23 @@
+{-# LANGUAGE CPP #-}
+
 import Test.Tasty
 import Test.Tasty.QuickCheck
 import Test.Tasty.Runners (NumThreads(..))
 
 import Data.Password.Types
 
+#ifdef CABAL_FLAG_argon2
 import Argon2 (testArgon2)
+#endif
+#ifdef CABAL_FLAG_bcrypt
 import Bcrypt (testBcrypt)
+#endif
+#ifdef CABAL_FLAG_pbkdf2
 import PBKDF2 (testPBKDF2)
+#endif
+#ifdef CABAL_FLAG_scrypt
 import Scrypt (testScrypt)
+#endif
 import Validate (testValidate)
 
 main :: IO ()
@@ -15,9 +25,17 @@ main = defaultMain $ localOption (NumThreads 1) $
   testGroup "Password"
     [ testProperty "Password" $ \pass ->
         unsafeShowPassword (mkPassword pass) === pass
+#ifdef CABAL_FLAG_argon2
     , testArgon2
+#endif
+#ifdef CABAL_FLAG_bcrypt
     , testBcrypt
+#endif
+#ifdef CABAL_FLAG_pbkdf2
     , testPBKDF2
+#endif
+#ifdef CABAL_FLAG_scrypt
     , testScrypt
+#endif
     , testValidate
     ]


### PR DESCRIPTION
This adds 4 Cabal flags to `password` which control whether or not the various hashing algorithms are exposed by the library. Each flag controls one corresponding hashing algorithm, and disabling the flag removes that flag's module from the library.

To allow for the tests to compile and run in all instances, this also exposes the `Internal` module as a non-PVP'd module to avoid relying on any particular hashing algorithm module for re-exports.

NB: the doctests in `password-instances` *do not pass* when `bcrypt` is disabled for `password`. This is because they rely on the `Bcrypt` module. Unfortunately, there's not much I can do about this - Cabal has been very slow to even consider the possibility that you'd want to use flags for controlling what parts of the API are exposed.

## Motivation

The argon2 implementation from `cryptonite` is [still broken](https://github.com/haskell-crypto/cryptonite/issues/360) on M1 Macs. I've got a project that uses this library for the scrypt implementation, and I can't compile it on M1 Macs so long as `password` exports argon2, thanks to [this Nix patch](https://github.com/NixOS/nixpkgs/pull/163303) which causes usage of argon2 to type-error.

Currently, I'm solving this by manually patching the library in Nix, but I'd prefer not to maintain a manual patch. It would be easier for me if I could simply specify that the package should be built without argon2 support, which I don't use.