### PR TITLE
Updating package constraints and CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,7 @@ on:
 jobs:
   cabal:
     name: cabal / ghc-${{matrix.ghc}} / ${{ matrix.os }}
-    continue-on-error: ${{ matrix.ghc == '9.4.2'}}
+    continue-on-error: ${{ matrix.ghc == '9.4.4'}}
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
@@ -22,8 +22,8 @@ jobs:
           - "8.8.4"
           - "8.10.7"
           - "9.0.2"
-          - "9.2.4"
-          - "9.4.2"
+          - "9.2.5"
+          - "9.4.4"
 
     steps:
     - uses: actions/checkout@v2
@@ -69,7 +69,8 @@ jobs:
           - "--resolver lts-16" # GHC 8.8.4
           - "--resolver lts-18" # GHC 8.10.7
           - "--resolver lts-19" # GHC 9.0.2
-          - "--resolver nightly" # GHC 9.2.4
+          - "--resolver lts-20" # GHC 9.2.5
+          - "--resolver nightly" # GHC 9.4.4
 
     steps:
     - uses: actions/checkout@v2

--- a/password-types/password-types.cabal
+++ b/password-types/password-types.cabal
@@ -37,8 +37,8 @@ library
   build-depends:
       base        >= 4.9 && < 5
     , bytestring            < 1
-    , memory
-    , text                  < 1.3
+    , memory                < 1
+    , text                  < 3
   ghc-options:
       -Wall
   default-language:

--- a/password/password.cabal
+++ b/password/password.cabal
@@ -71,12 +71,12 @@ library
   build-depends:
       base        >= 4.9      && < 5
     , base64      >= 0.3      && < 0.5
-    , bytestring  >= 0.10.8.1 && < 0.12
-    , cryptonite  >= 0.15.1
-    , memory      >= 0.14
+    , bytestring  >= 0.9      && < 0.12
+    , cryptonite  >= 0.15.1   && < 0.31
+    , memory                     < 1
     , password-types             < 2
     , template-haskell
-    , text        >= 1.2.2    && < 1.3
+    , text        >= 1.2.2    && < 3
   ghc-options:
       -Wall
   default-language:


### PR DESCRIPTION
Loosened some boundaries and added some upper boundaries (but only on major versions, since that's the only time anything should break for these packages)

Also updated CI definition to check the new/correct GHC versions. And it should build with the current dependency boundaries.