### PR TITLE
password.cabal: bumped bytestring dependency to < 0.13

### DIFF
--- a/password/password.cabal
+++ b/password/password.cabal
@@ -99,7 +99,7 @@ library
   build-depends:
       base        >= 4.9      && < 5
     , base64      >= 0.3      && < 0.5
-    , bytestring  >= 0.9      && < 0.12
+    , bytestring  >= 0.9      && < 0.13
     , cryptonite  >= 0.15.1   && < 0.31
     , memory                     < 1
     , password-types             < 2

--- a/password/src/Data/Password/Internal.hs
+++ b/password/src/Data/Password/Internal.hs
@@ -24,7 +24,7 @@ module Data.Password.Internal (
     -- $setup
   ) where
 
-import Control.Monad.IO.Class (MonadIO(liftIO))
+import Control.Monad.IO.Class (MonadIO (liftIO))
 import Crypto.Random (getRandomBytes)
 import Data.ByteArray (Bytes, convert)
 import Data.ByteString (ByteString)


### PR DESCRIPTION
Tested locally, and works fine.
Testing in CI here. (We basically only use `ByteString` and `length` from the `bytestring` library, so we might even just change this dependency to `< 1`? But then we'd have to be careful if we start using other functionality from the `bytestring` package. :thinking: 