### PR TITLE
Extra tweaks to CLI

### DIFF
--- a/hie.yaml
+++ b/hie.yaml
@@ -20,3 +20,6 @@ cradle:
           component: "password-instances:test:doctests"
         - path: "./password-instances/test/tasty"
           component: "password-instances:test:password-instances-tasty"
+
+        - path: "./password-cli/app"
+          component: "password-cli:exe:password-cli"

--- a/password-cli/ChangeLog.md
+++ b/password-cli/ChangeLog.md
@@ -1,3 +1,27 @@
+## 0.1.1.0
+
+-   Small refactor and quality of life additions.
+    Thanks to [@Vlix](https://github.com/Vlix)
+    [#72](https://github.com/cdepillabout/password/pull/72)
+
+-   Changes include:
+    - More complete explanation of the CLI in the README.
+    - Added more description of commands and options.
+    - Added option to read literal contents of a file.
+    - Hash output now adds a newline when using the CLI interactively. (on Unix)
+    - Added `--version` to only output the version of the CLI.
+
 ## 0.1.0.0
 
--   Initial version.
+-   First minimal working CLI to hash passwords and verify hashes.
+    Thanks to [@blackheaven](https://github.com/blackheaven)
+    [#70](https://github.com/cdepillabout/password/pull/70)
+
+-   Functionality includes:
+    - Hashing (`Argon2`, `bcrypt`, `PBKDF2`, `scrypt`) interactively,
+      piped to `stdin`, or from the first line in a provided file.
+    - Checking a hash (`Argon2`, `bcrypt`, `PBKDF2`, `scrypt`) that is
+      provided through a CLI option, or from a provided file. The password
+      can be entered interactively, piped to `stdin` or from the first
+      line in a provided file.
+    - Option to disable logging to stdout or stderr. `-q|--quiet`

--- a/password-cli/README.md
+++ b/password-cli/README.md
@@ -20,35 +20,33 @@ The following sections give examples of how the CLI can be used.
 ### Hashing a password interactively
 
 Hashing a password interactively is as easy as
-```
-user@computer $ password-cli hash bcrypt
+```console
+$ password-cli hash bcrypt
 Enter password:
 ```
 where the input is then hidden and the hash is printed to the screen, resulting in
-```
-user@computer $ password-cli hash bcrypt
+```console
+$ password-cli hash bcrypt
 Enter password:
 $2b$10$JuNbIWqVQD2EldT481zEEuaVKROrYhsHXLjM/Tx3e7ahJQxVw7N4y
-user@computer $
 ```
 
 ### Hashing a password with pipes
 
 When piping in the password from a file or other program:
-```
-user@computer $ cat password.txt | password-cli hash pbkdf2
+```console
+$ cat password.txt | password-cli hash pbkdf2
 Enter password:
-sha512:25000:8ZJ1T55Y0sPRwltXNe/2fA==:aA0BT1WlTg+t2pSr8E6+l2zJW88rmUiDlKeohSOnzS0nLOumDSyK0FfsiNJBvWvWVkB2r6IMxRqelk4LZR33ow==user@computer $
+sha512:25000:8ZJ1T55Y0sPRwltXNe/2fA==:aA0BT1WlTg+t2pSr8E6+l2zJW88rmUiDlKeohSOnzS0nLOumDSyK0FfsiNJBvWvWVkB2r6IMxRqelk4LZR33ow==
 ```
 You'll notice the output has no newline, so you can easily pipe the resulting
 hash into a file or other program. When piping the result to a file, you'll
 probably want to use `--quiet` or `-q` to make sure the `Enter password:` prompt
 isn't also saved to the file.
-```
-user@computer $ cat password.txt | password-cli hash pbkdf2 --quiet > password.hash
-user@computer $ cat password.hash && echo
+```console
+$ cat password.txt | password-cli hash pbkdf2 --quiet > password.hash
+$ cat password.hash
 sha512:25000:iFYCOgfOgMPp0NuPXhyucw==:XUMDNnqZo2LH08CIZr+1nbTke3N6pE95FcbZA+4A1Ng4dWHnnl4SMUTn3KXFtB0uZRrEhArLatLAH1Oo8brcVw==
-user@computer $
 ```
 When piping in the password, the first line of the file (i.e. up to the first newline)
 is read and taken as the password. This is also the case if the password is provided
@@ -59,9 +57,9 @@ file contents as the password.
 
 Instead of piping in the contents of a file, you can also just provide the path
 to the file.
-```
-user@computer $ password-cli hash scrypt --password-file password.txt
-14|8|1|mdSECCGuEMf7GQOp9EX5EYLMW9Jwe6Dma7fwbxuNwvs=|KSh5jxOEiQPMjfng2D05/G1baiF2LyluWgg3Cfzh5arJUF3K7irRIBXoKAT/xCO11oPmsgDD7TT6l6FQth9f4g==user@computer $
+```console
+$ password-cli hash scrypt --password-file password.txt
+14|8|1|mdSECCGuEMf7GQOp9EX5EYLMW9Jwe6Dma7fwbxuNwvs=|KSh5jxOEiQPMjfng2D05/G1baiF2LyluWgg3Cfzh5arJUF3K7irRIBXoKAT/xCO11oPmsgDD7TT6l6FQth9f4g==
 ```
 Here you don't have to pass in the `--quiet` option, since the password is already provided
 so the CLI doesn't print `Enter password:` to the screen.
@@ -70,30 +68,30 @@ so the CLI doesn't print `Enter password:` to the screen.
 
 Just like when hashing a password, you can input the password manually, through pipes, or
 by providing a `--password-file`.
-```
-user@computer $ # Interactively check password
-user@computer $ password-cli check argon2 --hash "SOME-HASH"
+```console
+$ # Interactively check password
+$ password-cli check argon2 --hash "SOME-HASH"
 Enter password:
 Password matches provided hash
-user@computer $ echo $?
+$ echo $?
 0
 ```
 If the provided hash doesn't match the password, `Password does not match provided hash`
 will be shown and the exit code will be `1` to indicate a failed match.
-```
-user@computer $ # Pipe in the password.
-user@computer $ cat password.txt | password-cli check argon2 --hash "SOME-HASH" --quiet
-user@computer $ echo $?
+```console
+$ # Pipe in the password.
+$ cat password.txt | password-cli check argon2 --hash "SOME-HASH" --quiet
+$ echo $?
 0
-user@computer $ # Give the WRONG password file.
-user@computer $ password-cli check argon2 --hash "SOME-HASH" --password-file password.txt.wrong --quiet
-user@computer $ echo $?
+$ # Give the WRONG password file.
+$ password-cli check argon2 --hash "SOME-HASH" --password-file password.txt.wrong --quiet
+$ echo $?
 1
 ```
 
 You can also provide the hash from file contents by providing the path to the `--hash-file`
 option. Just like the default of the `--password-file` option, this will only read up to the
 first newline.
-```
-user@computer $ password-cli check argon2 --hash-file password.hash
+```console
+$ password-cli check argon2 --hash-file password.hash
 ```

--- a/password-cli/README.md
+++ b/password-cli/README.md
@@ -1,4 +1,4 @@
-# password-cli
+# `password-cli`
 
 [![Build Status](https://github.com/cdepillabout/password/workflows/password/badge.svg)](http://github.com/cdepillabout/password)
 [![Hackage](https://img.shields.io/hackage/v/password-cli.svg)](https://hackage.haskell.org/package/password-cli)
@@ -6,17 +6,94 @@
 [![Stackage Nightly](http://stackage.org/package/password-cli/badge/nightly)](http://stackage.org/nightly/package/password-cli)
 [![BSD3 license](https://img.shields.io/badge/license-BSD3-blue.svg)](./LICENSE)
 
-This package provides a simple CLI for [password](https://hackage.haskell.org/package/password) package.
+This package provides a simple CLI for the [`password`](https://hackage.haskell.org/package/password) package.
+As such it supports all the algorithms that the [`password`](https://hackage.haskell.org/package/password)
+package supports, which at the time of writing are `Argon2`, `brypt`, `PBKDF2` and `scrypt`.
 
-Pipeline usage:
+At the moment, the default settings are used for each algorithm, but this will probably become configurable in
+a later version of the CLI.
 
+## Example usage
+
+The following sections give examples of how the CLI can be used.
+
+### Hashing a password interactively
+
+Hashing a password interactively is as easy as
 ```
-$ password-cli check argon2 --quiet --hash $(password-cli hash argon2 --quiet)
+user@computer $ password-cli hash bcrypt
+Enter password:
+```
+where the input is then hidden and the hash is printed to the screen, resulting in
+```
+user@computer $ password-cli hash bcrypt
+Enter password:
+$2b$10$JuNbIWqVQD2EldT481zEEuaVKROrYhsHXLjM/Tx3e7ahJQxVw7N4y
+user@computer $
 ```
 
-Interactive mode (default):
+### Hashing a password with pipes
 
+When piping in the password from a file or other program:
 ```
-$ password-cli hash argon2
-$ password-cli check argon2 --hash "SOME-HASH"
+user@computer $ cat password.txt | password-cli hash pbkdf2
+Enter password:
+sha512:25000:8ZJ1T55Y0sPRwltXNe/2fA==:aA0BT1WlTg+t2pSr8E6+l2zJW88rmUiDlKeohSOnzS0nLOumDSyK0FfsiNJBvWvWVkB2r6IMxRqelk4LZR33ow==user@computer $
+```
+You'll notice the output has no newline, so you can easily pipe the resulting
+hash into a file or other program. When piping the result to a file, you'll
+probably want to use `--quiet` or `-q` to make sure the `Enter password:` prompt
+isn't also saved to the file.
+```
+user@computer $ cat password.txt | password-cli hash pbkdf2 --quiet > password.hash
+user@computer $ cat password.hash && echo
+sha512:25000:iFYCOgfOgMPp0NuPXhyucw==:XUMDNnqZo2LH08CIZr+1nbTke3N6pE95FcbZA+4A1Ng4dWHnnl4SMUTn3KXFtB0uZRrEhArLatLAH1Oo8brcVw==
+user@computer $
+```
+When piping in the password, the first line of the file (i.e. up to the first newline)
+is read and taken as the password. This is also the case if the password is provided
+from a file, though you can set the `--literal-contents` flag to use the entire literal
+file contents as the password.
+
+### Hashing a password from a file
+
+Instead of piping in the contents of a file, you can also just provide the path
+to the file.
+```
+user@computer $ password-cli hash scrypt --password-file password.txt
+14|8|1|mdSECCGuEMf7GQOp9EX5EYLMW9Jwe6Dma7fwbxuNwvs=|KSh5jxOEiQPMjfng2D05/G1baiF2LyluWgg3Cfzh5arJUF3K7irRIBXoKAT/xCO11oPmsgDD7TT6l6FQth9f4g==user@computer $
+```
+Here you don't have to pass in the `--quiet` option, since the password is already provided
+so the CLI doesn't print `Enter password:` to the screen.
+
+### Verifying a password hash
+
+Just like when hashing a password, you can input the password manually, through pipes, or
+by providing a `--password-file`.
+```
+user@computer $ # Interactively check password
+user@computer $ password-cli check argon2 --hash "SOME-HASH"
+Enter password:
+Password matches provided hash
+user@computer $ echo $?
+0
+```
+If the provided hash doesn't match the password, `Password does not match provided hash`
+will be shown and the exit code will be `1` to indicate a failed match.
+```
+user@computer $ # Pipe in the password.
+user@computer $ cat password.txt | password-cli check argon2 --hash "SOME-HASH" --quiet
+user@computer $ echo $?
+0
+user@computer $ # Give the WRONG password file.
+user@computer $ password-cli check argon2 --hash "SOME-HASH" --password-file password.txt.wrong --quiet
+user@computer $ echo $?
+1
+```
+
+You can also provide the hash from file contents by providing the path to the `--hash-file`
+option. Just like the default of the `--password-file` option, this will only read up to the
+first newline.
+```
+user@computer $ password-cli check argon2 --hash-file password.hash
 ```

--- a/password-cli/app/Main.hs
+++ b/password-cli/app/Main.hs
@@ -1,198 +1,86 @@
-{-# LANGUAGE DuplicateRecordFields #-}
 {-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE RecordWildCards #-}
 
 module Main (main) where
 
-import Control.Exception (bracket_)
-import Control.Monad (unless, void)
-import Data.Version (showVersion)
-import qualified Data.Password.Argon2 as Argon2
+import Control.Exception (bracket_, evaluate)
+import Control.Monad (unless, void, (<=<))
+import qualified Data.ByteString.Char8 as B (readFile)
 import Data.Password.Bcrypt (PasswordCheck (..))
-import qualified Data.Password.Bcrypt as Bcrypt
-import qualified Data.Password.PBKDF2 as PBKDF2
-import qualified Data.Password.Scrypt as Scrypt
-import Data.Password.Types
-import Data.Text (Text)
+import Data.Password.Types (Password, mkPassword)
+import Data.Text as T (Text, strip)
+import qualified Data.Text.Encoding as TE
 import qualified Data.Text.IO as T
 import Options.Applicative
-import Paths_password_cli (version)
 import System.Exit (exitFailure)
-import System.IO (IOMode(ReadMode), hSetEcho, stdin, stderr, withFile)
+import System.IO (IOMode (ReadMode), hIsTerminalDevice, hSetEcho, stderr, stdin, stdout, withFile)
+
+import Options
 
 main :: IO ()
 main =
   customExecParser (prefs showHelpOnEmpty) cliOpts >>= runCmd
 
-data Cmd
-  = HashCmd HashOpts
-  | CheckCmd CheckOpts
-  | HelpCmd (Maybe String)
+runCmd :: CLIOptions -> IO ()
+runCmd CLIOptions{..} =
+    case cmd of
+        HashCmd opts -> runHashCmd quiet opts
+        CheckCmd opts -> runCheckCmd quiet opts
+        HelpCmd cmds -> void $ runHelpCmd cmds
 
-data HashOpts = HashOpts {
-    quiet :: Bool,
-    password :: Maybe FilePath,
-    hashAlgorithm :: HashAlgorithm
-  }
+runHashCmd :: Bool -> HashOpts -> IO ()
+runHashCmd quiet HashOpts {..} = do
+    pw <- getPassword quiet hashPassword
+    hash <- hashWithAlgorithm pw hashAlgorithm
+    b <- hIsTerminalDevice stdin
+    let output =
+            if b then T.putStrLn else T.putStr
+    output hash
 
-data CheckOpts = CheckOpts {
-    hash :: Either FilePath Text,
-    quiet :: Bool,
-    password :: Maybe FilePath,
-    checkAlgorithm :: CheckAlgorithm
-  }
-
-data HashAlgorithm
-  = PBKDF2HashAlgo PBKDF2.PBKDF2Params
-  | BcryptHashAlgo Int
-  | ScryptHashAlgo Scrypt.ScryptParams
-  | Argon2HashAlgo Argon2.Argon2Params
-
-data CheckAlgorithm
-  = PBKDF2CheckAlgo
-  | BcryptCheckAlgo
-  | ScryptCheckAlgo
-  | Argon2CheckAlgo
-
-cliOpts :: ParserInfo Cmd
-cliOpts = info commandsParser (fullDesc <> header ("Password CLI " <> showVersion version))
+runCheckCmd :: Bool -> CheckOpts -> IO ()
+runCheckCmd quiet CheckOpts {..} = do
+    pw <- getPassword quiet checkPassword
+    hashedPW <- getHash hash
+    case checkWithAlgorithm pw hashedPW checkAlgorithm of
+        PasswordCheckSuccess ->
+            qLog stdout "Password matches provided hash"
+        PasswordCheckFail -> do
+            qLog stderr "Password does not match provided hash"
+            exitFailure
   where
-    commandsParser :: Parser Cmd
-    commandsParser =
-      hsubparser
-        ( command
-            "hash"
-            (info (HashCmd <$> hashOptsParser) (progDesc "hash password"))
-            <> command
-              "check"
-              (info (CheckCmd <$> checkOptsParser) (progDesc "check hashed password"))
-            <> command "help" (info (HelpCmd <$> optional (argument str (metavar "COMMAND")) <**> helper) (progDesc "Show command help"))
-        )
-    hashOptsParser :: Parser HashOpts
-    hashOptsParser =
-      HashOpts
-        <$> switch (short 'q' <> long "quiet")
-        <*> optional (option str (metavar "PASSWORD-FILE" <> long "password-file"))
-        <*> algorithmHashParser
-    checkOptsParser :: Parser CheckOpts
-    checkOptsParser =
-      CheckOpts
-        <$> (   (Right <$> option str (metavar "HASH" <> long "hash"))
-            <|> (Left <$> option str (metavar "HASH-FILE" <> long "hash-file")))
-        <*> switch (short 'q' <> long "quiet")
-        <*> optional (option str (metavar "PASSWORD-FILE" <> long "password-file"))
-        <*> algorithmCheckParser
-    algorithmHashParser :: Parser HashAlgorithm
-    algorithmHashParser =
-      hsubparser
-        ( command "argon2" (info (Argon2HashAlgo <$> algoParser argon2Def) (progDesc "Argon2"))
-            <> command "bcrypt" (info (BcryptHashAlgo <$> algoParser bcryptDef) (progDesc "Bcrypt"))
-            <> command "pbkdf2" (info (PBKDF2HashAlgo <$> algoParser pbkdf2Def) (progDesc "PBKDF2"))
-            <> command "scrypt" (info (ScryptHashAlgo <$> algoParser scryptDef) (progDesc "Scrypt"))
-        )
-    algorithmCheckParser :: Parser CheckAlgorithm
-    algorithmCheckParser =
-      hsubparser
-        ( command "argon2" (info (pure Argon2CheckAlgo) (progDesc "Argon2"))
-            <> command "bcrypt" (info (pure BcryptCheckAlgo) (progDesc "Bcrypt"))
-            <> command "pbkdf2" (info (pure PBKDF2CheckAlgo) (progDesc "PBKDF2"))
-            <> command "scrypt" (info (pure ScryptCheckAlgo) (progDesc "Scrypt"))
-        )
+    qLog h = unless quiet . T.hPutStrLn h
 
-data AlgorithmeDef a p = AlgorithmeDef
-  { algoParser :: Parser p
-  , algoHash :: p -> Password -> IO (PasswordHash a)
-  , algoCheck :: Password -> PasswordHash a -> PasswordCheck
-  }
+runHelpCmd :: [String] -> IO CLIOptions
+runHelpCmd cmds =
+  let args = cmds ++ ["-h"]
+   in handleParseResult $ execParserPure defaultPrefs cliOpts args
 
-argon2Def :: AlgorithmeDef Argon2.Argon2 Argon2.Argon2Params
-argon2Def = AlgorithmeDef
-  { algoParser = pure Argon2.defaultParams
-  , algoHash = Argon2.hashPasswordWithParams
-  , algoCheck = Argon2.checkPassword
-  }
-
-bcryptDef :: AlgorithmeDef Bcrypt.Bcrypt Int
-bcryptDef = AlgorithmeDef
-  { algoParser = pure Bcrypt.defaultParams
-  , algoHash = Bcrypt.hashPasswordWithParams
-  , algoCheck = Bcrypt.checkPassword
-  }
-
-pbkdf2Def :: AlgorithmeDef PBKDF2.PBKDF2 PBKDF2.PBKDF2Params
-pbkdf2Def = AlgorithmeDef
-  { algoParser = pure PBKDF2.defaultParams
-  , algoHash = PBKDF2.hashPasswordWithParams
-  , algoCheck = PBKDF2.checkPassword
-  }
-
-scryptDef :: AlgorithmeDef Scrypt.Scrypt Scrypt.ScryptParams
-scryptDef = AlgorithmeDef
-  { algoParser = pure Scrypt.defaultParams
-  , algoHash = Scrypt.hashPasswordWithParams
-  , algoCheck = Scrypt.checkPassword
-  }
-
-runCmd :: Cmd -> IO ()
-runCmd =
-  \case
-    HashCmd opts -> runHashCmd opts
-    CheckCmd opts -> runCheckCmd opts
-    HelpCmd mCmd -> runHelpCmd mCmd
-
-runHashCmd :: HashOpts -> IO ()
-runHashCmd HashOpts {..} = do
-  pw <- getPassword quiet password
-  hash <-
-        case hashAlgorithm of
-            Argon2HashAlgo p -> unPasswordHash <$> algoHash argon2Def p pw
-            BcryptHashAlgo p -> unPasswordHash <$> algoHash bcryptDef p pw
-            PBKDF2HashAlgo p -> unPasswordHash <$> algoHash pbkdf2Def p pw
-            ScryptHashAlgo p -> unPasswordHash <$> algoHash scryptDef p pw
-  T.putStr hash
-
-runCheckCmd :: CheckOpts -> IO ()
-runCheckCmd CheckOpts {..} = do
-  pw <- getPassword quiet password
-  checked <-
-        case checkAlgorithm of
-            Argon2CheckAlgo -> algoCheck argon2Def pw <$> getHash hash
-            BcryptCheckAlgo -> algoCheck bcryptDef pw <$> getHash hash
-            PBKDF2CheckAlgo -> algoCheck pbkdf2Def pw <$> getHash hash
-            ScryptCheckAlgo -> algoCheck scryptDef pw <$> getHash hash
-  case checked of
-    PasswordCheckSuccess ->
-      unless quiet $
-        T.putStrLn "Hash and password match"
-    PasswordCheckFail -> do
-      unless quiet $
-        T.hPutStrLn stderr "Hash and password do not match"
-      exitFailure
-
-runHelpCmd :: Maybe String -> IO ()
-runHelpCmd mCmd =
-  let args = maybe id (:) mCmd ["-h"]
-   in void $ handleParseResult $ execParserPure defaultPrefs cliOpts args
-
-getPassword :: Bool -> Maybe FilePath -> IO Password
-getPassword quiet =
-  \case
-    Just path ->
-      mkPassword <$> readLine path
+getPassword :: Bool -> Maybe FromFileOptions -> IO Password
+getPassword quiet = \case
+    Just FromFileOptions{..} ->
+        mkPassword <$> readLine parseLiteralContents fromFile
     Nothing -> do
-      unless quiet $
-        putStrLn "Enter password:"
-      bracket_
-        (hSetEcho stdin False)
-        (hSetEcho stdin True)
-        (mkPassword <$> T.hGetLine stdin)
+        unless quiet $
+            putStrLn "Enter password:"
+        bracket_
+            (hSetEcho stdin False)
+            (hSetEcho stdin True)
+            (mkPassword <$> T.hGetLine stdin)
 
-getHash :: Either FilePath Text -> IO (PasswordHash a)
-getHash =
-  \case
-    Left path -> PasswordHash <$> readLine path
-    Right hash -> return $ PasswordHash hash
+getHash :: Either FromFileOptions Text -> IO Text
+getHash = \case
+    Right hash -> pure hash
+    Left FromFileOptions{..} -> readLine parseLiteralContents fromFile
 
-readLine :: FilePath -> IO Text
-readLine x = withFile x ReadMode T.hGetLine
+readLine :: Bool -> FilePath -> IO Text
+readLine literal x
+    | literal = readFullFile x
+    -- When not given the 'parseLiteralContents' flag, we want to be
+    -- lenient, and ignore white space around any hash, since those
+    -- will never be part of any hash, and probably also not a password.
+    | otherwise = T.strip <$> withFile x ReadMode T.hGetLine
+
+-- | Copied from newest 'text-2.1' 'Data.Text.IO.Utf8' module
+readFullFile :: FilePath -> IO Text
+readFullFile = evaluate . TE.decodeUtf8 <=< B.readFile

--- a/password-cli/app/Options.hs
+++ b/password-cli/app/Options.hs
@@ -1,0 +1,190 @@
+{-# LANGUAGE LambdaCase #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE RecordWildCards #-}
+
+module Options where
+
+import qualified Data.Password.Argon2 as Argon2
+import Data.Password.Bcrypt (PasswordCheck (..))
+import qualified Data.Password.Bcrypt as Bcrypt
+import qualified Data.Password.PBKDF2 as PBKDF2
+import qualified Data.Password.Scrypt as Scrypt
+import Data.Password.Types
+import Data.Text (Text)
+import Data.Version (showVersion)
+import Options.Applicative
+import Paths_password_cli (version)
+
+data CLIOptions = CLIOptions
+    { quiet :: Bool
+    -- ^ Prevent any logging to stdout or stderr.
+    , cmd :: Cmd
+    -- ^ What command
+    }
+
+data Cmd
+    = HashCmd HashOpts
+    | CheckCmd CheckOpts
+    | HelpCmd [String]
+
+data FromFileOptions = FromFileOptions
+    { fromFile :: FilePath
+    , parseLiteralContents :: Bool
+    }
+
+data HashOpts = HashOpts
+    { hashPassword :: Maybe FromFileOptions
+    , hashAlgorithm :: HashAlgorithm
+    }
+
+data CheckOpts = CheckOpts
+    { hash :: Either FromFileOptions Text
+    , checkPassword :: Maybe FromFileOptions
+    , checkAlgorithm :: CheckAlgorithm
+    }
+
+data HashAlgorithm
+    = PBKDF2HashAlgo PBKDF2.PBKDF2Params
+    | BcryptHashAlgo Int
+    | ScryptHashAlgo Scrypt.ScryptParams
+    | Argon2HashAlgo Argon2.Argon2Params
+
+hashWithAlgorithm :: Password -> HashAlgorithm -> IO Text
+hashWithAlgorithm pw = \case
+    Argon2HashAlgo p ->
+        unPasswordHash <$> Argon2.hashPasswordWithParams p pw
+    BcryptHashAlgo p ->
+        unPasswordHash <$> Bcrypt.hashPasswordWithParams p pw
+    PBKDF2HashAlgo p ->
+        unPasswordHash <$> PBKDF2.hashPasswordWithParams p pw
+    ScryptHashAlgo p ->
+        unPasswordHash <$> Scrypt.hashPasswordWithParams p pw
+
+data CheckAlgorithm
+    = PBKDF2CheckAlgo
+    | BcryptCheckAlgo
+    | ScryptCheckAlgo
+    | Argon2CheckAlgo
+
+checkWithAlgorithm :: Password -> Text -> CheckAlgorithm -> PasswordCheck
+checkWithAlgorithm pw hashT = \case
+    Argon2CheckAlgo -> Argon2.checkPassword pw hash
+    BcryptCheckAlgo -> Bcrypt.checkPassword pw hash
+    PBKDF2CheckAlgo -> PBKDF2.checkPassword pw hash
+    ScryptCheckAlgo -> Scrypt.checkPassword pw hash
+  where
+    hash :: PasswordHash a
+    hash = PasswordHash hashT
+
+cliOpts :: ParserInfo CLIOptions
+cliOpts =
+    info cliOptsParser infoMods
+  where
+    v = showVersion version
+    infoMods =
+        fullDesc
+            <> header ("Password CLI " <> v)
+            <> progDesc
+                "A command line interface to hash and check passwords in the terminal."
+    cliOptsParser =
+        CLIOptions
+            <$> switch (short 'q' <> long "quiet" <> help "Suppress logging to stdout and stderr")
+            <*> commandsParser
+            <**> simpleVersioner v
+            <**> helper
+
+commandsParser :: Parser Cmd
+commandsParser =
+    hsubparser $
+        command "hash" hashCmd
+            <> command "check" checkCmd
+            <> command "help" helpCmd
+  where
+    hashCmd =
+        info (HashCmd <$> hashOptsParser) $
+            progDesc
+                "Hash a password from a file, or via stdin. Outputs to stdout.\
+                \ (Will add a newline at the end when used interactively on Unix)"
+    checkCmd =
+        info (CheckCmd <$> checkOptsParser) $
+            progDesc
+                "Verify a hashed password from file or stdin. Returns exit code 0\
+                \ when successful, and exit code 1 when the password did not match."
+    helpCmd =
+        info (HelpCmd <$> many (argument str (metavar "COMMAND"))) $
+            progDesc "Show help text for the given command(s)"
+
+hashOptsParser :: Parser HashOpts
+hashOptsParser =
+    HashOpts <$> passwordFileOption <*> hashParser
+
+checkOptsParser :: Parser CheckOpts
+checkOptsParser =
+    CheckOpts <$> hashOption <*> passwordFileOption <*> checkParser
+  where
+    hashOption =
+        Right <$> strOption (metavar "HASH" <> long "hash" <> help hashOptionMsg)
+            <|> Left <$> hashFileOption
+    hashOptionMsg = "Provide the hash as an option."
+
+fromFileOption :: Parser FilePath -> Parser FromFileOptions
+fromFileOption fileOption =
+    FromFileOptions <$> fileOption <*> literalParseSwitch
+  where
+    literalParseSwitch =
+        switch $ long "literal-contents" <> help helpMsg
+    helpMsg =
+        "Hash all contents of the file. (by default only reads first line)"
+
+passwordFileOption :: Parser (Maybe FromFileOptions)
+passwordFileOption =
+    optional . fromFileOption $
+        strOption (metavar "FILE" <> long "password-file" <> help "Hash password from file contents")
+
+
+hashFileOption :: Parser FromFileOptions
+hashFileOption =
+    fromFileOption $
+        strOption (metavar "FILE" <> long "hash-file" <> help "Use hash from file contents")
+
+
+data AlgoParsers a =
+    AlgoParsers
+        { argon2Parser :: Parser a
+        , bcryptParser :: Parser a
+        , pbkdf2Parser :: Parser a
+        , scryptParser :: Parser a
+        , commandDesc :: String -> String
+        }
+
+algorithmParser :: AlgoParsers a -> Parser a
+algorithmParser AlgoParsers{..} =
+    hsubparser
+        ( commandGroup "Available algorithms:"
+            <> command "argon2" (info argon2Parser (progDesc $ commandDesc "Argon2"))
+            <> command "bcrypt" (info bcryptParser (progDesc $ commandDesc "bcrypt"))
+            <> command "pbkdf2" (info pbkdf2Parser (progDesc $ commandDesc "PBKDF2"))
+            <> command "scrypt" (info scryptParser (progDesc $ commandDesc "scrypt"))
+        )
+
+hashParser :: Parser HashAlgorithm
+hashParser =
+    algorithmParser
+        AlgoParsers
+            { argon2Parser = pure $ Argon2HashAlgo Argon2.defaultParams
+            , bcryptParser = pure $ BcryptHashAlgo Bcrypt.defaultParams
+            , pbkdf2Parser = pure $ PBKDF2HashAlgo PBKDF2.defaultParams
+            , scryptParser = pure $ ScryptHashAlgo Scrypt.defaultParams
+            , commandDesc = ("Hash a password using " <>)
+            }
+
+checkParser :: Parser CheckAlgorithm
+checkParser =
+    algorithmParser
+        AlgoParsers
+            { argon2Parser = pure Argon2CheckAlgo
+            , bcryptParser = pure BcryptCheckAlgo
+            , pbkdf2Parser = pure PBKDF2CheckAlgo
+            , scryptParser = pure ScryptCheckAlgo
+            , commandDesc = \algo -> "Check a " <> algo <> " hash"
+            }

--- a/password-cli/app/Options.hs
+++ b/password-cli/app/Options.hs
@@ -90,8 +90,14 @@ cliOpts =
         CLIOptions
             <$> switch (short 'q' <> long "quiet" <> help "Suppress logging to stdout and stderr")
             <*> commandsParser
-            <**> simpleVersioner v
+            <**> versionOpt v
             <**> helper
+
+-- Copied over from 'optparse-applicative-0.17.1.0's 'simpleVersioner'
+versionOpt :: String -> Parser (a -> a)
+versionOpt v =
+    infoOption v $
+        long "version" <> help "Show version information" <> hidden
 
 commandsParser :: Parser Cmd
 commandsParser =

--- a/password-cli/app/Options.hs
+++ b/password-cli/app/Options.hs
@@ -127,24 +127,27 @@ checkOptsParser =
             <|> Left <$> hashFileOption
     hashOptionMsg = "Provide the hash as an option."
 
-fromFileOption :: Parser FilePath -> Parser FromFileOptions
-fromFileOption fileOption =
+fromFileOption :: Bool -> Parser FilePath -> Parser FromFileOptions
+fromFileOption acceptLiteral fileOption =
     FromFileOptions <$> fileOption <*> literalParseSwitch
   where
-    literalParseSwitch =
-        switch $ long "literal-contents" <> help helpMsg
+    literalParseSwitch
+        | acceptLiteral =
+            switch $ long "literal-contents" <> help helpMsg
+        | otherwise = pure False
     helpMsg =
         "Hash all contents of the file. (by default only reads first line)"
 
 passwordFileOption :: Parser (Maybe FromFileOptions)
 passwordFileOption =
-    optional . fromFileOption $
+    optional . fromFileOption True $
         strOption (metavar "FILE" <> long "password-file" <> help "Hash password from file contents")
 
-
+-- | We don't want to allow the '--literal-contents' option,
+-- because hashes never have newlines and 'readLine' reads up to the first newline.
 hashFileOption :: Parser FromFileOptions
 hashFileOption =
-    fromFileOption $
+    fromFileOption False $
         strOption (metavar "FILE" <> long "hash-file" <> help "Use hash from file contents")
 
 

--- a/password-cli/password-cli.cabal
+++ b/password-cli/password-cli.cabal
@@ -1,7 +1,7 @@
 cabal-version:  3.0
 
 name:           password-cli
-version:        0.1.0.0
+version:        0.1.1.0
 category:       CLI
 synopsis:       use password from your CLI
 description:    A simple CLI tool to interact with password
@@ -26,11 +26,13 @@ executable password-cli
   -- type: exitcode-stdio-1.0
   main-is: Main.hs
   other-modules:
+    Options
     Paths_password_cli
   hs-source-dirs: app
   ghc-options: -threaded -rtsopts -with-rtsopts=-N -Wall -Wcompat -Widentities -Wincomplete-record-updates -Wincomplete-uni-patterns -Wpartial-fields -Wredundant-constraints
   build-depends:
       base
+    , bytestring >= 0.9 && < 1
     , password ^>= 3.0.3.0
     , password-types ^>= 1.0
     , optparse-applicative >= 0.14.3 && < 0.19


### PR DESCRIPTION
Added a bunch of documentation, help strings and restructured the internals a bit.

@cdepillabout Take your time reviewing this. There's no rush.

Also, I'm wondering if it's even necessary to publish `password-cli` to hackage.com :thinking: 
It's only an executable, and hackage is for libraries. It being in the repo is good enough for anyone who'd like to build it, right?

Should we maybe add the fact that there IS a CLI to the `password/README` and link to the repo in there?
(When we're happy with the state of the CLI, of course)