### PR TITLE
Adjusting for base64 1.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,7 @@ on:
 jobs:
   cabal:
     name: cabal / ghc-${{matrix.ghc}} / ${{ matrix.os }}
-    continue-on-error: ${{ matrix.ghc == '9.6.3'}}
+    continue-on-error: ${{ matrix.ghc == '9.8.1'}}
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
@@ -18,12 +18,12 @@ jobs:
           - macOS-latest
         cabal: ["latest"]
         ghc:
-          - "8.8.4"
           - "8.10.7"
           - "9.0.2"
           - "9.2.8"
-          - "9.4.7"
-          - "9.6.3"
+          - "9.4.8"
+          - "9.6.4"
+          - "9.8.1"
 
     steps:
     - uses: actions/checkout@v2
@@ -65,12 +65,12 @@ jobs:
       matrix:
         stack: ["latest"]
         resolver:
-          - "--resolver lts-16" # GHC 8.8.4
           - "--resolver lts-18" # GHC 8.10.7
           - "--resolver lts-19" # GHC 9.0.2
           - "--resolver lts-20" # GHC 9.2.8
-          - "--resolver lts-21" # GHC 9.4.7
-          - "--resolver nightly" # GHC 9.6.3
+          - "--resolver lts-21" # GHC 9.4.8
+          - "--resolver lts-22" # GHC 9.6.4
+          - "--resolver nightly" # GHC 9.8.1
 
     steps:
     - uses: actions/checkout@v2

--- a/password/ChangeLog.md
+++ b/password/ChangeLog.md
@@ -3,10 +3,14 @@
 ## 3.0.4.0
 
 -   Support `base64` package up to and including `base64-1.0`.
--   Added a Cabal flag `crypton` to replace the current `cryptonite`
-    dependency with the `crypton` package. In a future release, this
-    will be reversed, so that the `crypton` flag will be a no-op and
-    you'd have to supply `cryptonite` to build with the `cryptonite` package.
+-   Added the Cabal flags `crypton` and `cryptonite` to choose which dependency to
+    build with. Right now the default is `cryptonite` and setting `crypton` changes
+    it to `crypton`. Setting the `cryptonite` flag does nothing at the moment, but
+    will replace the `crypton` flag in a future major release, so if you want to keep
+    using the `cryptonite` package you should start building with this flag.
+    When the flags get switched the `crypton` package will be the default and the
+    `crypton` flag will turn into a no-op, and you'll have to supply the `cryptonite`
+    flag to build with the `cryptonite` package.
     Thanks to [@Vlix](https://github.com/Vlix)
     [#74](https://github.com/cdepillabout/password/pull/74)
 

--- a/password/ChangeLog.md
+++ b/password/ChangeLog.md
@@ -1,9 +1,19 @@
 # Changelog for `password`
 
+## 3.0.4.0
+
+-   Support `base64` package up to and including `base64-1.0`.
+-   Added a Cabal flag `crypton` to replace the current `cryptonite`
+    dependency with the `crypton` package. In a future release, this
+    will be reversed, so that the `crypton` flag will be a no-op and
+    you'd have to supply `cryptonite` to build with the `cryptonite` package.
+    Thanks to [@Vlix](https://github.com/Vlix)
+    [#74](https://github.com/cdepillabout/password/pull/74)
+
 ## 3.0.3.0
 
--  Added `bcrypt` `defaultParams` used by `hashPassword`
-  Thanks to [@blackheaven](https://github.com/blackheaven)
+-   Added `bcrypt` `defaultParams` used by `hashPassword`
+    Thanks to [@blackheaven](https://github.com/blackheaven)
     [#70](https://github.com/cdepillabout/password/pull/70)
 
 ## 3.0.2.2

--- a/password/password.cabal
+++ b/password/password.cabal
@@ -183,7 +183,6 @@ test-suite password-tasty
     , base64
     , password-types
     , bytestring
-    , cryptonite
     , memory
     , quickcheck-instances
     , scrypt
@@ -206,3 +205,9 @@ test-suite password-tasty
   if flag(scrypt)
     cpp-options:
       -DCABAL_FLAG_scrypt
+  if flag(crypton)
+    build-depends:
+      crypton
+  else
+    build-depends:
+      cryptonite

--- a/password/password.cabal
+++ b/password/password.cabal
@@ -98,7 +98,7 @@ library
       Data.Password.Internal
   build-depends:
       base        >= 4.9      && < 5
-    , base64      >= 0.3      && < 0.5
+    , base64      >= 0.3      && < 1.1
     , bytestring  >= 0.9      && < 0.13
     , cryptonite  >= 0.15.1   && < 0.31
     , memory                     < 1

--- a/password/password.cabal
+++ b/password/password.cabal
@@ -47,17 +47,24 @@ extra-source-files:
     ChangeLog.md
 
 flag argon2
-  description: Compile with argon2 support?
+  description: Compile with Argon2 support?
   default: True
   manual: True
 
 flag bcrypt
-  description: Compile with Scrypt support?
+  description: Compile with bcrypt support?
   default: True
   manual: True
 
 flag crypton
-  description: Compile with Scrypt support?
+  description: Use the [crypton] library as the cryptographic backend.
+  default: False
+  manual: True
+
+flag cryptonite
+  description:
+    Use the [cryptonite] library as the cryptographic backend.
+    (Does nothing until a future major version)
   default: False
   manual: True
 
@@ -67,7 +74,7 @@ flag pbkdf2
   manual: True
 
 flag scrypt
-  description: Compile with Scrypt support?
+  description: Compile with scrypt support?
   default: True
   manual: True
 
@@ -113,6 +120,9 @@ library
       -Wall
   default-language:
       Haskell2010
+  -- At some future major version bump, this should
+  -- be changed to the [cryptonite] flag and that
+  -- `if flag(cryptonite) build-depends: cryptonite`
   if flag(crypton)
     build-depends:
       crypton     >= 0.31   && < 0.35
@@ -205,6 +215,9 @@ test-suite password-tasty
   if flag(scrypt)
     cpp-options:
       -DCABAL_FLAG_scrypt
+  -- At some future major version bump, this should
+  -- be changed to the [cryptonite] flag and that
+  -- `if flag(cryptonite) build-depends: cryptonite`
   if flag(crypton)
     build-depends:
       crypton

--- a/password/password.cabal
+++ b/password/password.cabal
@@ -1,7 +1,7 @@
 cabal-version: 1.12
 
 name:           password
-version:        3.0.3.0
+version:        3.0.4.0
 category:       Data
 synopsis:       Hashing and checking of passwords
 description:

--- a/password/password.cabal
+++ b/password/password.cabal
@@ -56,6 +56,11 @@ flag bcrypt
   default: True
   manual: True
 
+flag crypton
+  description: Compile with Scrypt support?
+  default: False
+  manual: True
+
 flag pbkdf2
   description: Compile with PBKDF2 support?
   default: True
@@ -100,7 +105,6 @@ library
       base        >= 4.9      && < 5
     , base64      >= 0.3      && < 1.1
     , bytestring  >= 0.9      && < 0.13
-    , cryptonite  >= 0.15.1   && < 0.31
     , memory                     < 1
     , password-types             < 2
     , template-haskell
@@ -109,6 +113,12 @@ library
       -Wall
   default-language:
       Haskell2010
+  if flag(crypton)
+    build-depends:
+      crypton     >= 0.31   && < 0.35
+  else
+    build-depends:
+      cryptonite  >= 0.15.1   && < 0.31
 
 test-suite doctests
   type:

--- a/password/src/Data/Password/Argon2.hs
+++ b/password/src/Data/Password/Argon2.hs
@@ -74,6 +74,9 @@ import Control.Monad (guard)
 import Control.Monad.IO.Class (MonadIO (liftIO))
 import Crypto.Error (throwCryptoError)
 import Crypto.KDF.Argon2 as Argon2 (Options (..), Variant (..), Version (..), hash)
+#if MIN_VERSION_base64(1,0,0)
+import Data.Base64.Types (extractBase64)
+#endif
 import Data.ByteArray (Bytes, constEq, convert)
 import Data.ByteString as B (ByteString, length)
 import Data.ByteString.Base64 (encodeBase64)
@@ -205,7 +208,11 @@ hashPasswordWithSalt params@Argon2Params{..} s@(Salt salt) pass =
     , encodeWithoutPadding key
     ]
   where
+#if MIN_VERSION_base64(1,0,0)
+    encodeWithoutPadding = T.dropWhileEnd (== '=') . extractBase64 . encodeBase64
+#else
     encodeWithoutPadding = T.dropWhileEnd (== '=') . encodeBase64
+#endif
     parameters = T.intercalate ","
         [ "m=" <> showT argon2MemoryCost
         , "t=" <> showT argon2TimeCost

--- a/password/src/Data/Password/Internal.hs
+++ b/password/src/Data/Password/Internal.hs
@@ -48,9 +48,6 @@ import Data.Text.Encoding (decodeUtf8, encodeUtf8)
 import Text.Read (readMaybe)
 
 -- $setup
-#if MIN_VERSION_base64(1,0,0)
--- >>> import Data.Base64.Types (extractBase64)
-#endif
 -- >>> import Data.ByteString as B (length)
 -- >>> import Data.ByteString.Base64 (encodeBase64)
 -- >>> import Data.Text as T (dropWhileEnd)
@@ -120,6 +117,7 @@ showT = T.pack . show
 -- | (UNSAFE) Pad a base64 text to "length `rem` 4 == 0" with "="
 --
 #if MIN_VERSION_base64(1,0,0)
+-- >>> import Data.Base64.Types (extractBase64)
 -- prop> \bs -> let b64 = extractBase64 (encodeBase64 bs) in unsafePad64 (T.dropWhileEnd (== '=') b64) == b64
 #else
 -- prop> \bs -> let b64 = encodeBase64 bs in unsafePad64 (T.dropWhileEnd (== '=') b64) == b64

--- a/password/src/Data/Password/Internal.hs
+++ b/password/src/Data/Password/Internal.hs
@@ -28,7 +28,11 @@ import Control.Monad.IO.Class (MonadIO (liftIO))
 import Crypto.Random (getRandomBytes)
 import Data.ByteArray (Bytes, convert)
 import Data.ByteString (ByteString)
+#if MIN_VERSION_base64(1,0,0)
+import Data.ByteString.Base64 (decodeBase64Untyped)
+#else
 import Data.ByteString.Base64 (decodeBase64)
+#endif
 #if !MIN_VERSION_base(4,13,0)
 import Data.Semigroup ((<>))
 #endif
@@ -44,6 +48,9 @@ import Data.Text.Encoding (decodeUtf8, encodeUtf8)
 import Text.Read (readMaybe)
 
 -- $setup
+#if MIN_VERSION_base64(1,0,0)
+-- >>> import Data.Base64.Types (extractBase64)
+#endif
 -- >>> import Data.ByteString as B (length)
 -- >>> import Data.ByteString.Base64 (encodeBase64)
 -- >>> import Data.Text as T (dropWhileEnd)
@@ -91,7 +98,11 @@ fromBytes = decodeUtf8 . convert
 
 -- | Decodes a base64 'Text' to a regular 'ByteString' (if possible)
 from64 :: Text -> Maybe ByteString
+#if MIN_VERSION_base64(1,0,0)
+from64 = toMaybe . decodeBase64Untyped . encodeUtf8
+#else
 from64 = toMaybe . decodeBase64 . encodeUtf8
+#endif
   where
     toMaybe = either (const Nothing) Just
 {-# INLINE from64 #-}
@@ -108,7 +119,11 @@ showT = T.pack . show
 
 -- | (UNSAFE) Pad a base64 text to "length `rem` 4 == 0" with "="
 --
+#if MIN_VERSION_base64(1,0,0)
+-- prop> \bs -> let b64 = extractBase64 (encodeBase64 bs) in unsafePad64 (T.dropWhileEnd (== '=') b64) == b64
+#else
 -- prop> \bs -> let b64 = encodeBase64 bs in unsafePad64 (T.dropWhileEnd (== '=') b64) == b64
+#endif
 unsafePad64 :: Text -> Text
 unsafePad64 t
     | remains == 0 = t

--- a/password/src/Data/Password/PBKDF2.hs
+++ b/password/src/Data/Password/PBKDF2.hs
@@ -255,18 +255,16 @@ parsePBKDF2PasswordHashParams (PasswordHash passHash) = do
     -- "pbkdf2:sha256:150000:etc.etc."
     let passHash' = fromMaybe passHash $ "pbkdf2:" `T.stripPrefix` passHash
         paramList = T.split (== ':') passHash'
-    guard $ length paramList == 4
-    let [ algT,
-          iterationsT,
-          salt64,
-          hashedKey64 ] = paramList
-    pbkdf2Algorithm <- textToAlg algT
-    pbkdf2Iterations <- readT iterationsT
-    salt <- from64 salt64
-    hashedKey <- from64 hashedKey64
-    let pbkdf2OutputLength = fromIntegral $ C8.length hashedKey
-        pbkdf2Salt = fromIntegral $ C8.length salt
-    return (PBKDF2Params{..}, Salt salt, hashedKey)
+    case paramList of
+        [algT, iterationsT, salt64, hashedKey64] -> do
+            pbkdf2Algorithm <- textToAlg algT
+            pbkdf2Iterations <- readT iterationsT
+            salt <- from64 salt64
+            hashedKey <- from64 hashedKey64
+            let pbkdf2OutputLength = fromIntegral $ C8.length hashedKey
+                pbkdf2Salt = fromIntegral $ C8.length salt
+            return (PBKDF2Params{..}, Salt salt, hashedKey)
+        _ -> Nothing
 
 -- | Extracts 'PBKDF2Params' from a 'PasswordHash' 'PBKDF2'.
 --

--- a/password/src/Data/Password/PBKDF2.hs
+++ b/password/src/Data/Password/PBKDF2.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE CPP #-}
 {-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE RecordWildCards #-}
@@ -72,9 +73,12 @@ import Control.Monad (guard)
 import Control.Monad.IO.Class (MonadIO(liftIO))
 import Crypto.Hash.Algorithms as Crypto (MD5(..))
 import Crypto.KDF.PBKDF2 as PBKDF2
+#if MIN_VERSION_base64(1,0,0)
+import Data.Base64.Types (extractBase64)
+#endif
 import Data.ByteArray (ByteArray, ByteArrayAccess, Bytes, constEq, convert)
 import Data.ByteString (ByteString)
-import qualified Data.ByteString.Base64 as Base64
+import Data.ByteString.Base64 (encodeBase64)
 import qualified Data.ByteString.Char8 as C8 (length)
 import Data.Maybe (fromMaybe)
 import Data.Text (Text)
@@ -186,7 +190,11 @@ hashPasswordWithSalt params@PBKDF2Params{..} s@(Salt salt) pass =
     , b64 key
     ]
   where
-    b64 = Base64.encodeBase64
+#if MIN_VERSION_base64(1,0,0)
+    b64 = extractBase64 . encodeBase64
+#else
+    b64 = encodeBase64
+#endif
     key = hashPasswordWithSalt' params s pass
 
 -- | Only for internal use

--- a/password/src/Data/Password/Scrypt.hs
+++ b/password/src/Data/Password/Scrypt.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE CPP #-}
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE RecordWildCards #-}
 {-|
@@ -65,6 +66,9 @@ module Data.Password.Scrypt (
 import Control.Monad (guard)
 import Control.Monad.IO.Class (MonadIO(liftIO))
 import Crypto.KDF.Scrypt as Scrypt (Parameters(..), generate)
+#if MIN_VERSION_base64(1,0,0)
+import Data.Base64.Types (extractBase64)
+#endif
 import Data.ByteArray (Bytes, constEq, convert)
 import Data.ByteString (ByteString)
 import Data.ByteString.Base64 (encodeBase64)
@@ -180,11 +184,16 @@ hashPasswordWithSalt params@ScryptParams{..} s@(Salt salt) pass =
     [ showT scryptRounds
     , showT scryptBlockSize
     , showT scryptParallelism
-    , encodeBase64 salt
-    , encodeBase64 key
+    , toB64 salt
+    , toB64 key
     ]
   where
     key = hashPasswordWithSalt' params s pass
+#if MIN_VERSION_base64(1,0,0)
+    toB64 = extractBase64 . encodeBase64
+#else
+    toB64 = encodeBase64
+#endif
 
 -- | Only for internal use
 hashPasswordWithSalt' :: ScryptParams -> Salt Scrypt -> Password -> ByteString

--- a/password/src/Data/Password/Scrypt.hs
+++ b/password/src/Data/Password/Scrypt.hs
@@ -261,22 +261,20 @@ checkPassword pass passHash =
     return PasswordCheckSuccess
 
 parseScryptPasswordHashParams :: PasswordHash Scrypt -> Maybe (ScryptParams, Salt Scrypt, ByteString)
-parseScryptPasswordHashParams (PasswordHash passHash) = do
-    let paramList = T.split (== '|') passHash
-    guard $ length paramList == 5
-    let [ scryptRoundsT,
-          scryptBlockSizeT,
-          scryptParallelismT,
-          salt64,
-          hashedKey64 ] = paramList
-    scryptRounds <- readT scryptRoundsT
-    scryptBlockSize <- readT scryptBlockSizeT
-    scryptParallelism <- readT scryptParallelismT
-    salt <- from64 salt64
-    hashedKey <- from64 hashedKey64
-    let scryptOutputLength = fromIntegral $ C8.length hashedKey
-        scryptSalt = fromIntegral $ C8.length salt
-    return (ScryptParams{..}, Salt salt, hashedKey)
+parseScryptPasswordHashParams (PasswordHash passHash) =
+    case paramList of
+        [scryptRoundsT, scryptBlockSizeT, scryptParallelismT, salt64, hashedKey64] -> do
+            scryptRounds <- readT scryptRoundsT
+            scryptBlockSize <- readT scryptBlockSizeT
+            scryptParallelism <- readT scryptParallelismT
+            salt <- from64 salt64
+            hashedKey <- from64 hashedKey64
+            let scryptOutputLength = fromIntegral $ C8.length hashedKey
+                scryptSalt = fromIntegral $ C8.length salt
+            return (ScryptParams{..}, Salt salt, hashedKey)
+        _ -> Nothing
+  where
+    paramList = T.split (== '|') passHash
 
 -- | Extracts 'ScryptParams' from a 'PasswordHash' 'Scrypt'.
 --

--- a/stack.yaml
+++ b/stack.yaml
@@ -17,7 +17,7 @@
 #
 # resolver: ./custom-snapshot.yaml
 # resolver: https://example.com/snapshots/2018-01-01.yaml
-resolver: lts-21.25
+resolver: lts-22.7
 
 # User packages to be built.
 # Various formats can be used as shown in the example below.

--- a/stack.yaml
+++ b/stack.yaml
@@ -17,7 +17,7 @@
 #
 # resolver: ./custom-snapshot.yaml
 # resolver: https://example.com/snapshots/2018-01-01.yaml
-resolver: lts-21.13
+resolver: lts-21.25
 
 # User packages to be built.
 # Various formats can be used as shown in the example below.

--- a/stack.yaml.lock
+++ b/stack.yaml.lock
@@ -6,7 +6,7 @@
 packages: []
 snapshots:
 - completed:
-    sha256: 8017c7970c2a8a9510c60cc70ac245d59e0c34eb932b91d37af09fe59855d854
-    size: 640038
-    url: https://raw.githubusercontent.com/commercialhaskell/stackage-snapshots/master/lts/21/13.yaml
-  original: lts-21.13
+    sha256: 7b975b104cb3dbf0c297dfd01f936a4d2ee523241dd0b1ae960522b833fe3027
+    size: 714096
+    url: https://raw.githubusercontent.com/commercialhaskell/stackage-snapshots/master/lts/22/7.yaml
+  original: lts-22.7


### PR DESCRIPTION
Took the opportunity to also add a flag to build with `crypton`.

Bumped GHC version testing to 9.8.1 and dropped 8.8.4.

Bumped LTS to 22.7 to build with GHC 9.6.4 normally.