### PR TITLE
Moving over to `crypton` backend

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,7 @@ on:
 jobs:
   cabal:
     name: cabal / ghc-${{matrix.ghc}} / ${{ matrix.os }}
-    continue-on-error: ${{ matrix.ghc == '9.10.1' || (matrix.os == 'macOS-latest' && matrix.ghc == '9.0.2') }}
+    continue-on-error: ${{ matrix.ghc == '9.10.1' || matrix.os == 'macOS-latest' }}
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,7 @@ on:
 jobs:
   cabal:
     name: cabal / ghc-${{matrix.ghc}} / ${{ matrix.os }}
-    continue-on-error: ${{ matrix.ghc == '9.10.1' || matrix.os == 'macOS-latest' }}
+    continue-on-error: ${{ matrix.ghc == '9.10.1' }}
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
@@ -24,6 +24,9 @@ jobs:
           - "9.6.6"
           - "9.8.2"
           - "9.10.1"
+        exclude:
+          os: macOS-latest
+          ghc: "9.0.2"
 
     steps:
     - uses: actions/checkout@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,7 @@ on:
 jobs:
   cabal:
     name: cabal / ghc-${{matrix.ghc}} / ${{ matrix.os }}
-    continue-on-error: ${{ matrix.ghc == '9.10.1'}}
+    continue-on-error: ${{ matrix.ghc == '9.10.1' || (matrix.os == 'macOS-latest' && matrix.ghc == '9.0.2') }}
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,22 +21,22 @@ jobs:
           - "9.0.2"
           - "9.2.8"
           - "9.4.8"
-          - "9.6.5"
+          - "9.6.6"
           - "9.8.2"
           - "9.10.1"
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
       #if: github.event.action == 'opened' || github.event.action == 'synchronize' || github.event.ref == 'refs/heads/master'
 
-    - uses: haskell/actions/setup@v2
+    - uses: haskell-actions/setup@v2
       id: setup-haskell-cabal
       name: Setup Haskell
       with:
         ghc-version: ${{ matrix.ghc }}
         cabal-version: ${{ matrix.cabal }}
 
-    - uses: actions/cache@v3
+    - uses: actions/cache@v4
       name: Cache cabal-store
       with:
         path: ${{ steps.setup-haskell-cabal.outputs.cabal-store }}
@@ -68,20 +68,20 @@ jobs:
           - "--resolver lts-19" # GHC 9.0.2
           - "--resolver lts-20" # GHC 9.2.8
           - "--resolver lts-21" # GHC 9.4.8
-          - "--resolver lts-22" # GHC 9.6.5
+          - "--resolver lts-22" # GHC 9.6.6
           - "--resolver nightly" # GHC 9.8.2
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
       #if: github.event.action == 'opened' || github.event.action == 'synchronize' || github.event.ref == 'refs/heads/master'
 
-    - uses: haskell/actions/setup@v2
+    - uses: haskell-actions/setup@v2
       name: Setup Haskell Stack
       with:
         stack-version: ${{ matrix.stack }}
         enable-stack: true
 
-    - uses: actions/cache@v3
+    - uses: actions/cache@v4
       name: Cache ~/.stack
       with:
         path: ~/.stack

--- a/password-cli/password-cli.cabal
+++ b/password-cli/password-cli.cabal
@@ -33,7 +33,7 @@ executable password-cli
   build-depends:
       base
     , bytestring >= 0.9 && < 1
-    , password ^>= 3.0.3.0
+    , password ^>= 3.0.3.0 || ^>= 3.1.0.0
     , password-types ^>= 1.0
     , optparse-applicative >= 0.14.3 && < 0.19
     , text >= 1.2 && < 3

--- a/password/ChangeLog.md
+++ b/password/ChangeLog.md
@@ -1,5 +1,11 @@
 # Changelog for `password`
 
+## 3.1.0.0
+
+-   Switched default cryptographic backend library from `cryptonite` to `crypton`.
+    The `crypton` flag is now a no-op, and the `cryptonite` flag is needed to build
+    the `password` library using the `cryptonite` library.
+
 ## 3.0.4.0
 
 -   Support `base64` package up to and including `base64-1.0`.

--- a/password/ChangeLog.md
+++ b/password/ChangeLog.md
@@ -5,6 +5,8 @@
 -   Switched default cryptographic backend library from `cryptonite` to `crypton`.
     The `crypton` flag is now a no-op, and the `cryptonite` flag is needed to build
     the `password` library using the `cryptonite` library.
+    Thanks to [@Vlix](https://github.com/Vlix)
+    [#81](https://github.com/cdepillabout/password/pull/81)
 
 ## 3.0.4.0
 

--- a/password/password.cabal
+++ b/password/password.cabal
@@ -140,10 +140,8 @@ test-suite doctests
       base >=4.9 && <5
     , base-compat
     , doctest
-    , password
     , QuickCheck
     , quickcheck-instances
-    , template-haskell
   default-language:
       Haskell2010
 
@@ -192,7 +190,6 @@ test-suite password-tasty
     , bytestring
     , memory
     , quickcheck-instances
-    , scrypt
     , tasty
     , tasty-hunit
     , tasty-quickcheck
@@ -200,6 +197,12 @@ test-suite password-tasty
     , text
   default-language:
       Haskell2010
+
+  if os(darwin)
+    cpp-options: -DIS_MAC_OS
+  else
+    build-depends: scrypt
+
   if flag(argon2)
     cpp-options:
       -DCABAL_FLAG_argon2

--- a/password/password.cabal
+++ b/password/password.cabal
@@ -1,7 +1,7 @@
 cabal-version: 1.12
 
 name:           password
-version:        3.0.4.0
+version:        3.1.0.0
 category:       Data
 synopsis:       Hashing and checking of passwords
 description:
@@ -58,13 +58,13 @@ flag bcrypt
 
 flag crypton
   description: Use the [crypton] library as the cryptographic backend.
+    (Does nothing since version 3.1.0.0; might be removed in a future major version)
   default: False
   manual: True
 
 flag cryptonite
   description:
     Use the [cryptonite] library as the cryptographic backend.
-    (Does nothing until a future major version)
   default: False
   manual: True
 
@@ -120,15 +120,12 @@ library
       -Wall
   default-language:
       Haskell2010
-  -- At some future major version bump, this should
-  -- be changed to the [cryptonite] flag and that
-  -- `if flag(cryptonite) build-depends: cryptonite`
-  if flag(crypton)
-    build-depends:
-      crypton     >= 0.31   && < 1.1
-  else
+  if flag(cryptonite)
     build-depends:
       cryptonite  >= 0.15.1   && < 0.31
+  else
+    build-depends:
+      crypton     >= 0.31   && < 1.1
 
 test-suite doctests
   type:
@@ -215,12 +212,9 @@ test-suite password-tasty
   if flag(scrypt)
     cpp-options:
       -DCABAL_FLAG_scrypt
-  -- At some future major version bump, this should
-  -- be changed to the [cryptonite] flag and that
-  -- `if flag(cryptonite) build-depends: cryptonite`
-  if flag(crypton)
-    build-depends:
-      crypton
-  else
+  if flag(cryptonite)
     build-depends:
       cryptonite
+  else
+    build-depends:
+      crypton

--- a/password/src/Data/Password/Validate.hs
+++ b/password/src/Data/Password/Validate.hs
@@ -202,7 +202,7 @@ module Data.Password.Validate
 
 import Data.Char (chr, isAsciiLower, isAsciiUpper, isDigit, ord)
 import Data.Function (on)
-import Data.List (foldl')
+import Data.Foldable (foldl')
 
 import Data.Text (Text)
 import qualified Data.Text as T

--- a/password/src/Data/Password/Validate.hs
+++ b/password/src/Data/Password/Validate.hs
@@ -202,8 +202,9 @@ module Data.Password.Validate
 
 import Data.Char (chr, isAsciiLower, isAsciiUpper, isDigit, ord)
 import Data.Function (on)
+#if !MIN_VERSION_base(4,20,0)
 import Data.Foldable (foldl')
-
+#endif
 import Data.Text (Text)
 import qualified Data.Text as T
 import Language.Haskell.TH (Exp, Q, appE)

--- a/password/test/tasty/Scrypt.hs
+++ b/password/test/tasty/Scrypt.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE CPP #-}
 module Scrypt where
 
 import Data.Maybe (fromJust)
@@ -7,7 +8,9 @@ import Test.Tasty
 import Test.Tasty.QuickCheck
 import Test.QuickCheck.Instances.Text ()
 
+#ifndef IS_MAC_OS
 import qualified Crypto.Scrypt as Scrypt
+#endif
 import Data.Password.Types
 import Data.Password.Scrypt
 
@@ -24,7 +27,9 @@ testScrypt = testGroup "scrypt"
                  checkPassword
                  extractParams
                  testsParams8Rounds
+#ifndef IS_MAC_OS
   , testProperty "scrypt <-> cryptonite" $ withMaxSuccess 10 checkScrypt
+#endif
   ]
   where
     hash8Rounds = hashPasswordWithParams testsParams8Rounds
@@ -32,6 +37,7 @@ testScrypt = testGroup "scrypt"
     hash4Rounds = hashPasswordWithParams testsParams4Rounds
     testsParams4Rounds = defaultParams{ scryptRounds = 4, scryptSalt = 16 }
 
+#ifndef IS_MAC_OS
 checkScrypt :: Text -> Property
 checkScrypt pass = ioProperty $ do
   s@(Scrypt.Salt salt) <- Scrypt.newSalt
@@ -41,3 +47,4 @@ checkScrypt pass = ioProperty $ do
       PasswordHash ourHash =
         hashPasswordWithSalt defaultParams{ scryptRounds = 8 } (Salt salt) $ mkPassword pass
   return $ scryptHash === encodeUtf8 ourHash
+#endif

--- a/stack.yaml
+++ b/stack.yaml
@@ -41,7 +41,8 @@ packages:
 # Dependency packages to be pulled from upstream that are not in the resolver
 # using the same syntax as the packages field.
 # (e.g., acme-missiles-0.3)
-extra-deps: []
+extra-deps:
+  - crypton-1.0.0
 
 # Override default flag values for local packages and extra-deps
 # flags: {}

--- a/stack.yaml
+++ b/stack.yaml
@@ -17,7 +17,7 @@
 #
 # resolver: ./custom-snapshot.yaml
 # resolver: https://example.com/snapshots/2018-01-01.yaml
-resolver: lts-22.28
+resolver: lts-22.38
 
 # User packages to be built.
 # Various formats can be used as shown in the example below.
@@ -42,7 +42,7 @@ packages:
 # using the same syntax as the packages field.
 # (e.g., acme-missiles-0.3)
 extra-deps:
-  - crypton-1.0.0
+  - crypton-1.0.1
 
 # Override default flag values for local packages and extra-deps
 # flags: {}

--- a/stack.yaml
+++ b/stack.yaml
@@ -17,7 +17,7 @@
 #
 # resolver: ./custom-snapshot.yaml
 # resolver: https://example.com/snapshots/2018-01-01.yaml
-resolver: lts-22.24
+resolver: lts-22.28
 
 # User packages to be built.
 # Various formats can be used as shown in the example below.

--- a/stack.yaml.lock
+++ b/stack.yaml.lock
@@ -6,7 +6,7 @@
 packages: []
 snapshots:
 - completed:
-    sha256: 28a863b358647f2d952fe7085ba11561aeb63eca6bc6fd1ce8fcf1cfe63717f5
-    size: 719127
-    url: https://raw.githubusercontent.com/commercialhaskell/stackage-snapshots/master/lts/22/24.yaml
-  original: lts-22.24
+    sha256: 87da71cb0ae9ee1ea1bf51a8eb9812f39f779be76abc0a3c926defd8afda05d1
+    size: 719139
+    url: https://raw.githubusercontent.com/commercialhaskell/stackage-snapshots/master/lts/22/28.yaml
+  original: lts-22.28

--- a/stack.yaml.lock
+++ b/stack.yaml.lock
@@ -3,10 +3,17 @@
 # For more information, please see the documentation at:
 #   https://docs.haskellstack.org/en/stable/lock_files
 
-packages: []
+packages:
+- completed:
+    hackage: crypton-1.0.1@sha256:f41316fbc6ad878396e476355e27b70ac35c344d74e3eefafe709e03b192be9e,14527
+    pantry-tree:
+      sha256: b8f0a33755a0871d325300024592cd9306e393941248184e9c4faf417d4adfcd
+      size: 23276
+  original:
+    hackage: crypton-1.0.1
 snapshots:
 - completed:
-    sha256: 87da71cb0ae9ee1ea1bf51a8eb9812f39f779be76abc0a3c926defd8afda05d1
-    size: 719139
-    url: https://raw.githubusercontent.com/commercialhaskell/stackage-snapshots/master/lts/22/28.yaml
-  original: lts-22.28
+    sha256: 0964f3e2c04e21abf42e271490e6974bc923aac2f2fd595fcb53ad0c237dbed1
+    size: 720034
+    url: https://raw.githubusercontent.com/commercialhaskell/stackage-snapshots/master/lts/22/38.yaml
+  original: lts-22.38


### PR DESCRIPTION
Also updated a bit of the CI settings, since we got GHC 9.6.6 now.
And the `haskell/actions/setup` is now deprecated, using `haskell-actions/setup` now.