### PR TITLE
Make scrypt test dep optional and not required on darwin

### DIFF
--- a/password/ChangeLog.md
+++ b/password/ChangeLog.md
@@ -1,5 +1,13 @@
 # Changelog for `password`
 
+## 3.1.0.1
+
+-   Redo the conditionals in the `password.cabal` file so that the scrypt
+    library is only included as a test dependency on `x86_64`.  This generally
+    shouldn't affect users of the `password` library.
+    Thanks to [@sternenseemann](https://github.com/sternenseemann)
+    [#85](https://github.com/cdepillabout/password/pull/85)
+
 ## 3.1.0.0
 
 -   Switched default cryptographic backend library from `cryptonite` to `crypton`.

--- a/password/password.cabal
+++ b/password/password.cabal
@@ -154,6 +154,7 @@ test-suite password-tasty
       test/tasty
   main-is:
       Spec.hs
+
   other-modules:
       Data.Password.Internal
     -- We're also putting all the modules from
@@ -182,8 +183,10 @@ test-suite password-tasty
     other-modules:
       Scrypt
       Data.Password.Scrypt
+
   ghc-options:
       -threaded -O2 -rtsopts -with-rtsopts=-N
+
   build-depends:
       base >=4.9 && <5
     , base64
@@ -200,23 +203,28 @@ test-suite password-tasty
   default-language:
       Haskell2010
 
-  if os(darwin)
-    cpp-options: -DIS_MAC_OS
-  else
-    build-depends: scrypt
-
   if flag(argon2)
     cpp-options:
       -DCABAL_FLAG_argon2
+
   if flag(bcrypt)
     cpp-options:
       -DCABAL_FLAG_bcrypt
+
   if flag(pbkdf2)
     cpp-options:
       -DCABAL_FLAG_pbkdf2
+
   if flag(scrypt)
     cpp-options:
       -DCABAL_FLAG_scrypt
+
+    -- The scrypt package is optionally used in tests to ensure compatibility
+    -- between password and scrypt.  However, scrypt doesn't work on OSX, so
+    -- we only add the scrypt dependency if we're not building on OSX.
+    if !os(darwin)
+      build-depends: scrypt
+
   if flag(cryptonite)
     build-depends:
       cryptonite

--- a/password/password.cabal
+++ b/password/password.cabal
@@ -1,7 +1,7 @@
 cabal-version: 1.12
 
 name:           password
-version:        3.1.0.0
+version:        3.1.0.1
 category:       Data
 synopsis:       Hashing and checking of passwords
 description:

--- a/password/password.cabal
+++ b/password/password.cabal
@@ -220,9 +220,9 @@ test-suite password-tasty
       -DCABAL_FLAG_scrypt
 
     -- The scrypt package is optionally used in tests to ensure compatibility
-    -- between password and scrypt.  However, scrypt doesn't work on OSX, so
-    -- we only add the scrypt dependency if we're not building on OSX.
-    if !os(darwin)
+    -- between password and scrypt.  However, scrypt requires the x86_64 arch
+    -- with the SSE2 instruction set.
+    if arch(x86_64)
       build-depends: scrypt
 
   if flag(cryptonite)


### PR DESCRIPTION
This is a slight improvement on https://github.com/cdepillabout/password/pull/84.

I've also confirmed that `stack test --flag password:-scrypt password` builds without problems (on Linux at least).

See the following for more information:
- https://github.com/NixOS/nixpkgs/pull/351305
- https://github.com/cdepillabout/password/pull/84
